### PR TITLE
Add safety guard to seed migration and extend waitlist indexing

### DIFF
--- a/supabase/migrations/0099_seed_dev.sql
+++ b/supabase/migrations/0099_seed_dev.sql
@@ -1,4 +1,22 @@
--- SOLO DESARROLLO – DATOS INVENTADOS
+
+-- Esta migración solo debe ejecutarse en entornos de desarrollo o pruebas.
+-- Realizamos una verificación defensiva para evitar que se ejecute accidentalmente
+-- sobre una base de datos de producción.
+do $$
+declare
+    v_db_name text := current_database();
+    v_is_safe boolean;
+begin
+    v_is_safe := v_db_name ilike '%dev%'
+        or v_db_name ilike '%develop%'
+        or v_db_name ilike '%test%'
+        or v_db_name ilike '%local%'
+        or v_db_name ilike '%staging%';
+
+    if not v_is_safe then
+        raise exception '0099_seed_dev.sql solo puede ejecutarse en bases de datos de desarrollo/pruebas. Base de datos actual: %', v_db_name;
+    end if;
+end $$;
 
 -- Función auxiliar para generar citas de prueba
 create or replace function public.generate_test_appointments(
@@ -17,7 +35,19 @@ declare
     v_hour int;
     v_status text;
     v_counter int := 0;
+    v_db_name text := current_database();
+    v_is_safe boolean;
 begin
+    v_is_safe := v_db_name ilike '%dev%'
+        or v_db_name ilike '%develop%'
+        or v_db_name ilike '%test%'
+        or v_db_name ilike '%local%'
+        or v_db_name ilike '%staging%';
+
+    if not v_is_safe then
+        raise exception 'generate_test_appointments() solo está disponible en entornos de desarrollo/pruebas. Base de datos actual: %', v_db_name;
+    end if;
+
     -- Iterar sobre los días
     for v_date in
     select generate_series(

--- a/supabase/migrations/0101_waitlist_index_and_comments.sql
+++ b/supabase/migrations/0101_waitlist_index_and_comments.sql
@@ -1,0 +1,8 @@
+-- Add descriptive metadata and performance improvements
+
+comment on table public.appointments is 'Citas agendadas entre clientes y servicios disponibles.';
+comment on column public.appointments.status is 'Estado de la cita: pending, confirmed o cancelled.';
+
+create index if not exists idx_waitlists_active_service_date
+    on public.waitlists (service_id, desired_date)
+    where status = 'active';


### PR DESCRIPTION
## Summary
- block the development seed migration when the database name does not look like a dev or staging environment
- ensure the generate_test_appointments helper function stops if it runs outside dev/test databases
- add documentation comments to appointments and a partial index for active waitlist lookups

## Testing
- not run (SQL-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68dc17f02418832786163f8431a66686