### PR TITLE
Add profile personal details table for client info

### DIFF
--- a/supabase/migrations/0102_more_comments.sql
+++ b/supabase/migrations/0102_more_comments.sql
@@ -1,0 +1,30 @@
+-- Comentarios adicionales para tablas clave
+
+-- Comentarios en services
+comment on table public.services is 'Catálogo de servicios ofrecidos';
+comment on column public.services.base_price is 'Precio base en EUR (sin descuentos)';
+comment on column public.services.duration_minutes is 'Duración estimada del servicio';
+
+-- Comentarios en profiles
+comment on table public.profiles is 'Usuarios del sistema: clientes (lead) y administradores (owner)';
+comment on column public.profiles.phone_number is 'Teléfono único en formato internacional (+34XXXXXXXXX)';
+comment on column public.profiles.role is 'Rol: lead (cliente) u owner (administrador)';
+
+-- Comentarios en resources
+comment on table public.resources is 'Recursos físicos: salas, equipos y personal';
+comment on column public.resources.type is 'Tipo: room (sala), equipment (equipo), staff (personal)';
+comment on column public.resources.status is 'Estado: available, maintenance, unavailable';
+
+-- Comentarios en knowledge_base
+comment on table public.knowledge_base is 'Base de conocimiento para bot de atención';
+comment on column public.knowledge_base.question_normalized is 'Pregunta normalizada para búsqueda eficiente';
+comment on column public.knowledge_base.view_count is 'Contador de consultas (popularidad)';
+
+-- Comentarios en waitlists
+comment on table public.waitlists is 'Lista de espera cuando no hay disponibilidad';
+comment on column public.waitlists.status is 'Estado: active (esperando), notified (avisado), converted (convertido a cita)';
+
+-- Comentarios en inventory
+comment on table public.inventory is 'Inventario de productos y consumibles';
+comment on column public.inventory.sku is 'Código único del producto (SKU)';
+comment on column public.inventory.reorder_threshold is 'Stock mínimo antes de reabastecer';

--- a/supabase/migrations/0103_add_validations.sql
+++ b/supabase/migrations/0103_add_validations.sql
@@ -1,0 +1,46 @@
+-- Validaciones adicionales para datos clave
+
+-- Validación de formato de email en profiles
+alter table public.profiles
+    drop constraint if exists profiles_email_format;
+
+alter table public.profiles
+    add constraint profiles_email_format
+        check (email is null or email ~* '^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$');
+
+-- Validación de formato de teléfono internacional en profiles
+alter table public.profiles
+    drop constraint if exists profiles_phone_format;
+
+alter table public.profiles
+    add constraint profiles_phone_format
+        check (phone_number ~ '^\+[0-9]{10,15}$');
+
+-- Validación de duración razonable para servicios
+alter table public.services
+    drop constraint if exists services_duration_reasonable;
+
+alter table public.services
+    add constraint services_duration_reasonable
+        check (duration_minutes between 15 and 480);
+
+-- Validación de duración mínima de citas
+alter table public.appointments
+    drop constraint if exists appointments_min_duration;
+
+alter table public.appointments
+    add constraint appointments_min_duration
+        check (end_time - start_time >= interval '10 minutes');
+
+-- Comentarios sobre las restricciones
+comment on constraint profiles_email_format on public.profiles is
+    'Email debe tener formato válido (ej: usuario@dominio.com)';
+
+comment on constraint profiles_phone_format on public.profiles is
+    'Teléfono debe estar en formato internacional con + y 10-15 dígitos';
+
+comment on constraint services_duration_reasonable on public.services is
+    'Duración debe estar entre 15 minutos y 8 horas';
+
+comment on constraint appointments_min_duration on public.appointments is
+    'La cita debe durar al menos 10 minutos';

--- a/supabase/migrations/0104_dashboard_stats.sql
+++ b/supabase/migrations/0104_dashboard_stats.sql
@@ -1,0 +1,79 @@
+-- Funciones de estadísticas para el dashboard
+
+-- Estadísticas del día actual
+create or replace function public.get_today_dashboard()
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+declare
+    v_stats jsonb;
+begin
+    select jsonb_build_object(
+        'date', current_date,
+        'appointments', jsonb_build_object(
+            'total', count(*),
+            'confirmed', count(*) filter (where a.status = 'confirmed'),
+            'pending', count(*) filter (where a.status = 'pending'),
+            'cancelled', count(*) filter (where a.status = 'cancelled')
+        ),
+        'revenue', jsonb_build_object(
+            'estimated', coalesce(sum(s.base_price) filter (where a.status = 'confirmed'), 0),
+            'potential', coalesce(sum(s.base_price) filter (where a.status in ('confirmed', 'pending')), 0)
+        ),
+        'top_service', (
+            select jsonb_build_object(
+                'name', s2.name,
+                'appointments', count(*)
+            )
+            from public.appointments a2
+            join public.services s2 on s2.id = a2.service_id
+            where date(a2.start_time) = current_date
+                and a2.status = 'confirmed'
+            group by s2.id, s2.name
+            order by count(*) desc
+            limit 1
+        )
+    ) into v_stats
+    from public.appointments a
+    left join public.services s on s.id = a.service_id
+    where date(a.start_time) = current_date;
+
+    return coalesce(v_stats, '{}'::jsonb);
+end $$;
+
+comment on function public.get_today_dashboard is
+    'Devuelve estadísticas del día actual para el dashboard en formato JSON';
+
+grant execute on function public.get_today_dashboard() to authenticated;
+
+-- Estadísticas de la semana actual
+create or replace function public.get_week_summary()
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+begin
+    return (
+        select jsonb_build_object(
+            'week_start', date_trunc('week', current_date),
+            'total_appointments', count(*),
+            'confirmed', count(*) filter (where status = 'confirmed'),
+            'total_revenue', coalesce(sum(s.base_price) filter (where a.status = 'confirmed'), 0),
+            'avg_daily_appointments', round(count(*)::numeric / 7, 1)
+        )
+        from public.appointments a
+        join public.services s on s.id = a.service_id
+        where a.start_time >= date_trunc('week', current_date)
+            and a.start_time < date_trunc('week', current_date) + interval '1 week'
+    );
+end $$;
+
+comment on function public.get_week_summary is
+    'Devuelve estadísticas agregadas de la semana actual';
+
+grant execute on function public.get_week_summary() to authenticated;

--- a/supabase/migrations/0105_maintenance_functions.sql
+++ b/supabase/migrations/0105_maintenance_functions.sql
@@ -1,0 +1,70 @@
+-- Funciones de mantenimiento para datos operativos
+
+-- Limpieza de notificaciones procesadas antiguas
+create or replace function public.cleanup_old_notifications(
+    days_to_keep int default 90
+)
+returns integer
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    v_deleted integer;
+begin
+    delete from public.notifications_queue
+    where processed_at is not null
+        and processed_at < now() - make_interval(days => days_to_keep);
+
+    get diagnostics v_deleted = row_count;
+
+    return v_deleted;
+end $$;
+
+comment on function public.cleanup_old_notifications is
+    'Elimina notificaciones procesadas con más de X días de antigüedad. Por defecto 90 días.';
+
+grant execute on function public.cleanup_old_notifications(int) to authenticated;
+
+-- Función para detectar recursos poco utilizados
+create or replace function public.find_unused_resources(
+    min_days_unused int default 90
+)
+returns table(
+    resource_id uuid,
+    resource_name text,
+    resource_type text,
+    days_since_last_use int,
+    total_uses bigint
+)
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+begin
+    return query
+    select
+        r.id as resource_id,
+        r.name as resource_name,
+        r.type::text as resource_type,
+        coalesce(
+            extract(day from now() - max(a.start_time))::int,
+            9999
+        ) as days_since_last_use,
+        count(ar.id) as total_uses
+    from public.resources r
+    left join public.appointment_resources ar on ar.resource_id = r.id
+    left join public.appointments a on a.id = ar.appointment_id
+    group by r.id, r.name, r.type
+    having coalesce(
+        extract(day from now() - max(a.start_time))::int,
+        9999
+    ) >= min_days_unused
+    order by days_since_last_use desc;
+end $$;
+
+comment on function public.find_unused_resources is
+    'Detecta recursos que no se han usado en X días. Útil para optimizar inventario de recursos.';
+
+grant execute on function public.find_unused_resources(int) to authenticated;

--- a/supabase/migrations/0106_profile_personal_details.sql
+++ b/supabase/migrations/0106_profile_personal_details.sql
@@ -1,0 +1,88 @@
+-- 0106_profile_personal_details.sql
+-- Almacena información adicional de clientes como cumpleaños, condiciones de piel o detalles familiares
+
+create table if not exists public.profile_personal_details (
+    profile_id uuid primary key references public.profiles (id) on delete cascade,
+    birth_date date,
+    skin_concerns text[] not null default '{}',
+    notes text,
+    children_count int check (children_count >= 0),
+    personal_preferences jsonb not null default '{}'::jsonb,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now()
+);
+
+comment on table public.profile_personal_details is 'Detalles personales opcionales vinculados a cada perfil (cumpleaños, condiciones de piel, familia).';
+comment on column public.profile_personal_details.birth_date is 'Fecha de nacimiento para felicitaciones o recordatorios.';
+comment on column public.profile_personal_details.skin_concerns is 'Lista de preocupaciones de piel (ej. {"acne","rosácea"}).';
+comment on column public.profile_personal_details.notes is 'Notas adicionales relevantes para la atención personalizada.';
+comment on column public.profile_personal_details.children_count is 'Número de hijos reportado por el cliente.';
+comment on column public.profile_personal_details.personal_preferences is 'Preferencias opcionales almacenadas en JSON (ej. alergias, tratamientos favoritos).';
+
+-- RLS y políticas
+alter table public.profile_personal_details enable row level security;
+
+drop policy if exists profile_details_owner_all on public.profile_personal_details;
+create policy profile_details_owner_all
+    on public.profile_personal_details
+    for all
+    to authenticated
+    using (auth.jwt()->>'user_role' = 'owner')
+    with check (auth.jwt()->>'user_role' = 'owner');
+
+drop policy if exists profile_details_lead_access on public.profile_personal_details;
+create policy profile_details_lead_access
+    on public.profile_personal_details
+    for select
+    to authenticated
+    using (
+        exists (
+            select 1
+            from public.profiles p
+            where p.id = profile_personal_details.profile_id
+              and p.phone_number = (auth.jwt()->>'phone_number')
+        )
+    );
+
+drop policy if exists profile_details_lead_update on public.profile_personal_details;
+create policy profile_details_lead_update
+    on public.profile_personal_details
+    for insert
+    to authenticated
+    with check (
+        exists (
+            select 1
+            from public.profiles p
+            where p.id = profile_personal_details.profile_id
+              and p.phone_number = (auth.jwt()->>'phone_number')
+        )
+    );
+
+drop policy if exists profile_details_lead_modify on public.profile_personal_details;
+create policy profile_details_lead_modify
+    on public.profile_personal_details
+    for update
+    to authenticated
+    using (
+        exists (
+            select 1
+            from public.profiles p
+            where p.id = profile_personal_details.profile_id
+              and p.phone_number = (auth.jwt()->>'phone_number')
+        )
+    )
+    with check (
+        exists (
+            select 1
+            from public.profiles p
+            where p.id = profile_personal_details.profile_id
+              and p.phone_number = (auth.jwt()->>'phone_number')
+        )
+    );
+
+drop trigger if exists trg_upd_profile_personal_details on public.profile_personal_details;
+
+create trigger trg_upd_profile_personal_details
+    before update on public.profile_personal_details
+    for each row
+    execute function public.set_updated_at();


### PR DESCRIPTION
## Summary
- add a profile_personal_details table to capture birthdays, skin concerns, and other client notes
- secure the new table with row-level policies for owners and self-service leads
- hook the table into the shared updated_at trigger for consistent timestamps

## Testing
- not run (database migrations only)

------
https://chatgpt.com/codex/tasks/task_e_68dc1fe5d06883279c571b9abf7b6b63