### PR TITLE
Harden multitenant integrity for resource assignments and schedules

### DIFF
--- a/supabase/migrations/0200_add_multitenancy.sql
+++ b/supabase/migrations/0200_add_multitenancy.sql
@@ -1,0 +1,404 @@
+-- ===============================================
+-- Migration: 0200_add_multitenancy.sql
+-- Date: 2025-01-XX
+-- Purpose: Agregar soporte para múltiples negocios
+-- Breaking changes: Requiere asignar business_id a datos existentes
+-- Dependencies: Todas las migraciones previas
+-- ===============================================
+
+begin;
+
+-- ===============================================
+-- PASO 1: CREAR TABLA BUSINESSES
+-- ===============================================
+create table if not exists public.businesses (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  slug text unique not null check (slug ~ '^[a-z0-9-]+$'),
+  phone text,
+  email text,
+  address text,
+  metadata jsonb not null default '{}'::jsonb,
+  is_active boolean not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+comment on table public.businesses is 
+  'Negocios/clínicas que usan el sistema. Cada negocio tiene datos completamente aislados.';
+comment on column public.businesses.slug is 
+  'Identificador único para URLs amigables (ej: clinica-madrid-centro)';
+comment on column public.businesses.metadata is 
+  'Datos adicionales: logo, colores, configuración personalizada, etc.';
+
+create index if not exists idx_businesses_slug on public.businesses(slug);
+create index if not exists idx_businesses_active on public.businesses(is_active) where is_active = true;
+
+raise notice '[1/8] Tabla businesses creada';
+
+-- ===============================================
+-- PASO 2: CREAR NEGOCIO POR DEFECTO
+-- ===============================================
+insert into public.businesses (id, name, slug, metadata)
+values (
+  '00000000-0000-0000-0000-000000000000',
+  'Negocio Principal',
+  'negocio-principal',
+  '{"is_default": true}'::jsonb
+)
+on conflict (id) do nothing;
+
+raise notice '[2/8] Negocio por defecto creado';
+
+-- ===============================================
+-- PASO 3: AGREGAR COLUMNA business_id
+-- ===============================================
+alter table public.profiles 
+  add column if not exists business_id uuid references public.businesses(id) on delete cascade;
+
+alter table public.services 
+  add column if not exists business_id uuid references public.businesses(id) on delete cascade;
+
+alter table public.appointments 
+  add column if not exists business_id uuid references public.businesses(id) on delete cascade;
+
+alter table public.resources 
+  add column if not exists business_id uuid references public.businesses(id) on delete cascade;
+
+alter table public.inventory 
+  add column if not exists business_id uuid references public.businesses(id) on delete cascade;
+
+alter table public.knowledge_base 
+  add column if not exists business_id uuid references public.businesses(id) on delete cascade;
+
+alter table public.waitlists 
+  add column if not exists business_id uuid references public.businesses(id) on delete cascade;
+
+alter table public.audit_logs 
+  add column if not exists business_id uuid references public.businesses(id) on delete cascade;
+
+alter table public.cross_sell_rules 
+  add column if not exists business_id uuid references public.businesses(id) on delete cascade;
+
+alter table public.notifications_queue
+  add column if not exists business_id uuid references public.businesses(id) on delete cascade;
+
+alter table public.service_resource_requirements
+  add column if not exists business_id uuid references public.businesses(id) on delete cascade;
+
+alter table public.resource_blocks
+  add column if not exists business_id uuid references public.businesses(id) on delete cascade;
+
+alter table public.knowledge_suggestions
+  add column if not exists business_id uuid references public.businesses(id) on delete cascade;
+
+alter table public.appointment_resources
+  add column if not exists business_id uuid references public.businesses(id) on delete cascade;
+
+raise notice '[3/8] Columnas business_id agregadas';
+
+-- ===============================================
+-- PASO 4: MIGRAR DATOS EXISTENTES
+-- ===============================================
+update public.profiles set business_id = '00000000-0000-0000-0000-000000000000' where business_id is null;
+update public.services set business_id = '00000000-0000-0000-0000-000000000000' where business_id is null;
+update public.appointments set business_id = '00000000-0000-0000-0000-000000000000' where business_id is null;
+update public.resources set business_id = '00000000-0000-0000-0000-000000000000' where business_id is null;
+update public.inventory set business_id = '00000000-0000-0000-0000-000000000000' where business_id is null;
+update public.knowledge_base set business_id = '00000000-0000-0000-0000-000000000000' where business_id is null;
+update public.waitlists set business_id = '00000000-0000-0000-0000-000000000000' where business_id is null;
+update public.audit_logs set business_id = '00000000-0000-0000-0000-000000000000' where business_id is null;
+update public.cross_sell_rules set business_id = '00000000-0000-0000-0000-000000000000' where business_id is null;
+update public.notifications_queue set business_id = '00000000-0000-0000-0000-000000000000' where business_id is null;
+update public.service_resource_requirements set business_id = '00000000-0000-0000-0000-000000000000' where business_id is null;
+update public.resource_blocks set business_id = '00000000-0000-0000-0000-000000000000' where business_id is null;
+update public.knowledge_suggestions set business_id = '00000000-0000-0000-0000-000000000000' where business_id is null;
+update public.appointment_resources set business_id = '00000000-0000-0000-0000-000000000000' where business_id is null;
+
+raise notice '[4/8] Datos existentes migrados al negocio por defecto';
+
+-- ===============================================
+-- PASO 5: HACER business_id OBLIGATORIO
+-- ===============================================
+alter table public.profiles alter column business_id set not null;
+alter table public.services alter column business_id set not null;
+alter table public.appointments alter column business_id set not null;
+alter table public.resources alter column business_id set not null;
+alter table public.inventory alter column business_id set not null;
+alter table public.knowledge_base alter column business_id set not null;
+alter table public.waitlists alter column business_id set not null;
+alter table public.audit_logs alter column business_id set not null;
+alter table public.cross_sell_rules alter column business_id set not null;
+alter table public.notifications_queue alter column business_id set not null;
+alter table public.service_resource_requirements alter column business_id set not null;
+alter table public.resource_blocks alter column business_id set not null;
+alter table public.knowledge_suggestions alter column business_id set not null;
+alter table public.appointment_resources alter column business_id set not null;
+
+raise notice '[5/8] Columnas business_id marcadas como NOT NULL';
+
+-- ===============================================
+-- PASO 6: CREAR ÍNDICES DE RENDIMIENTO
+-- ===============================================
+create index if not exists idx_profiles_business on public.profiles(business_id);
+create index if not exists idx_services_business on public.services(business_id);
+create index if not exists idx_appointments_business on public.appointments(business_id);
+create index if not exists idx_resources_business on public.resources(business_id);
+create index if not exists idx_inventory_business on public.inventory(business_id);
+create index if not exists idx_kb_business on public.knowledge_base(business_id);
+create index if not exists idx_waitlists_business on public.waitlists(business_id);
+create index if not exists idx_audit_business on public.audit_logs(business_id);
+create index if not exists idx_cross_sell_business on public.cross_sell_rules(business_id);
+create index if not exists idx_nq_business on public.notifications_queue(business_id);
+create index if not exists idx_srr_business on public.service_resource_requirements(business_id);
+create index if not exists idx_rb_business on public.resource_blocks(business_id);
+create index if not exists idx_ks_business on public.knowledge_suggestions(business_id);
+create index if not exists idx_ar_business on public.appointment_resources(business_id);
+
+alter table public.profiles drop constraint if exists profiles_phone_number_key;
+create unique index if not exists idx_profiles_business_phone on public.profiles(business_id, phone_number);
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'services_id_business_key'
+      and conrelid = 'public.services'::regclass
+  ) then
+    alter table public.services
+      add constraint services_id_business_key unique (id, business_id);
+  end if;
+end $$;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'profiles_id_business_key'
+      and conrelid = 'public.profiles'::regclass
+  ) then
+    alter table public.profiles
+      add constraint profiles_id_business_key unique (id, business_id);
+  end if;
+end $$;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'resources_id_business_key'
+      and conrelid = 'public.resources'::regclass
+  ) then
+    alter table public.resources
+      add constraint resources_id_business_key unique (id, business_id);
+  end if;
+end $$;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'appointments_id_business_key'
+      and conrelid = 'public.appointments'::regclass
+  ) then
+    alter table public.appointments
+      add constraint appointments_id_business_key unique (id, business_id);
+  end if;
+end $$;
+
+raise notice '[6/8] Índices creados';
+
+-- ===============================================
+-- PASO 7: CONSTRAINTS DE INTEGRIDAD
+-- ===============================================
+alter table public.appointments
+  drop constraint if exists appt_same_business_service;
+
+alter table public.appointments
+  drop constraint if exists appt_same_business_profile;
+
+alter table public.service_resource_requirements
+  drop constraint if exists srr_same_business;
+
+alter table public.cross_sell_rules
+  drop constraint if exists csr_same_business;
+
+alter table public.appointments
+  drop constraint if exists appointments_profile_id_fkey;
+
+alter table public.appointments
+  drop constraint if exists appointments_service_id_fkey;
+
+alter table public.service_resource_requirements
+  drop constraint if exists service_resource_requirements_service_id_fkey;
+
+alter table public.service_resource_requirements
+  drop constraint if exists service_resource_requirements_resource_id_fkey;
+
+alter table public.cross_sell_rules
+  drop constraint if exists cross_sell_rules_trigger_service_id_fkey;
+
+alter table public.cross_sell_rules
+  drop constraint if exists cross_sell_rules_recommended_service_id_fkey;
+
+alter table public.waitlists
+  drop constraint if exists waitlists_service_id_fkey;
+
+alter table public.waitlists
+  drop constraint if exists waitlists_profile_id_fkey;
+
+alter table public.resource_blocks
+  drop constraint if exists resource_blocks_resource_id_fkey;
+
+alter table public.appointment_resources
+  drop constraint if exists appointment_resources_appointment_id_fkey;
+
+alter table public.appointment_resources
+  drop constraint if exists appointment_resources_resource_id_fkey;
+
+alter table public.audit_logs
+  drop constraint if exists audit_logs_profile_id_fkey;
+
+alter table public.appointments
+  add constraint fk_appointments_profile_business
+  foreign key (profile_id, business_id)
+  references public.profiles(id, business_id)
+  on delete cascade;
+
+alter table public.appointments
+  add constraint fk_appointments_service_business
+  foreign key (service_id, business_id)
+  references public.services(id, business_id)
+  on delete restrict;
+
+alter table public.service_resource_requirements
+  add constraint fk_srr_service_business
+  foreign key (service_id, business_id)
+  references public.services(id, business_id)
+  on delete cascade;
+
+alter table public.service_resource_requirements
+  add constraint fk_srr_resource_business
+  foreign key (resource_id, business_id)
+  references public.resources(id, business_id)
+  on delete cascade;
+
+alter table public.cross_sell_rules
+  add constraint fk_csr_trigger_service_business
+  foreign key (trigger_service_id, business_id)
+  references public.services(id, business_id)
+  on delete cascade;
+
+alter table public.cross_sell_rules
+  add constraint fk_csr_recommended_service_business
+  foreign key (recommended_service_id, business_id)
+  references public.services(id, business_id)
+  on delete cascade;
+
+alter table public.waitlists
+  add constraint fk_waitlists_service_business
+  foreign key (service_id, business_id)
+  references public.services(id, business_id)
+  on delete cascade;
+
+alter table public.waitlists
+  add constraint fk_waitlists_profile_business
+  foreign key (profile_id, business_id)
+  references public.profiles(id, business_id)
+  on delete cascade;
+
+alter table public.resource_blocks
+  add constraint fk_resource_blocks_resource_business
+  foreign key (resource_id, business_id)
+  references public.resources(id, business_id)
+  on delete cascade;
+
+alter table public.appointment_resources
+  add constraint fk_ar_appointment_business
+  foreign key (appointment_id, business_id)
+  references public.appointments(id, business_id)
+  on delete cascade;
+
+alter table public.appointment_resources
+  add constraint fk_ar_resource_business
+  foreign key (resource_id, business_id)
+  references public.resources(id, business_id)
+  on delete restrict;
+
+alter table public.audit_logs
+  add constraint fk_audit_logs_profile_business
+  foreign key (profile_id, business_id)
+  references public.profiles(id, business_id);
+
+raise notice '[7/8] Constraints de integridad creados';
+
+-- ===============================================
+-- PASO 8: FUNCIÓN HELPER
+-- ===============================================
+create or replace function auth.get_user_business_id()
+returns uuid
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select business_id 
+  from public.profiles 
+  where id = (auth.jwt()->>'sub')::uuid
+  limit 1
+$$;
+
+comment on function auth.get_user_business_id is 
+  'Retorna el business_id del usuario autenticado actualmente';
+
+raise notice '[8/8] Función helper creada';
+
+-- ===============================================
+-- RLS: Habilitar en businesses
+-- ===============================================
+alter table public.businesses enable row level security;
+
+drop policy if exists businesses_owner_read on public.businesses;
+create policy businesses_owner_read on public.businesses
+  for select to authenticated
+  using (id = auth.get_user_business_id());
+
+drop policy if exists businesses_admin_write on public.businesses;
+create policy businesses_admin_write on public.businesses
+  for all to authenticated
+  using (false)
+  with check (false);
+
+raise notice 'RLS configurado para businesses';
+
+commit;
+
+raise notice '========================================';
+raise notice 'Migración 0200_add_multitenancy completada exitosamente';
+raise notice '========================================';
+
+-- ===============================================
+-- ROLLBACK (en caso de emergencia)
+-- ===============================================
+-- begin;
+--   alter table profiles drop column if exists business_id;
+--   alter table services drop column if exists business_id;
+--   alter table appointments drop column if exists business_id;
+--   alter table resources drop column if exists business_id;
+--   alter table inventory drop column if exists business_id;
+--   alter table knowledge_base drop column if exists business_id;
+--   alter table waitlists drop column if exists business_id;
+--   alter table audit_logs drop column if exists business_id;
+--   alter table cross_sell_rules drop column if exists business_id;
+--   alter table notifications_queue drop column if exists business_id;
+--   alter table service_resource_requirements drop column if exists business_id;
+--   alter table resource_blocks drop column if exists business_id;
+--   alter table knowledge_suggestions drop column if exists business_id;
+--   alter table appointment_resources drop column if exists business_id;
+--   drop function if exists auth.get_user_business_id();
+--   drop table if exists businesses cascade;
+-- commit;

--- a/supabase/migrations/0201_update_rls_multitenancy.sql
+++ b/supabase/migrations/0201_update_rls_multitenancy.sql
@@ -1,0 +1,452 @@
+-- ===============================================
+-- Migration: 0201_update_rls_multitenancy.sql
+-- Purpose: Actualizar políticas RLS para multitenancy
+-- Dependencies: 0200_add_multitenancy.sql
+-- ===============================================
+
+begin;
+
+-- ===============================================
+-- PROFILES
+-- ===============================================
+drop policy if exists profiles_read on public.profiles;
+create policy profiles_read on public.profiles 
+  for select to authenticated
+  using (
+    business_id = auth.get_user_business_id()
+    or phone_number = (auth.jwt()->>'phone_number')
+  );
+
+drop policy if exists profiles_owner_insert on public.profiles;
+create policy profiles_owner_insert on public.profiles 
+  for insert to authenticated
+  with check (
+    auth.jwt()->>'user_role' = 'owner'
+    and business_id = auth.get_user_business_id()
+  );
+
+drop policy if exists profiles_owner_update on public.profiles;
+create policy profiles_owner_update on public.profiles 
+  for update to authenticated
+  using (
+    auth.jwt()->>'user_role' = 'owner'
+    and business_id = auth.get_user_business_id()
+  )
+  with check (
+    auth.jwt()->>'user_role' = 'owner'
+    and business_id = auth.get_user_business_id()
+  );
+
+drop policy if exists profiles_lead_update_self on public.profiles;
+create policy profiles_lead_update_self on public.profiles 
+  for update to authenticated
+  using (
+    phone_number = (auth.jwt()->>'phone_number')
+    and business_id = auth.get_user_business_id()
+  )
+  with check (
+    phone_number = (auth.jwt()->>'phone_number')
+    and business_id = auth.get_user_business_id()
+  );
+
+drop policy if exists profiles_owner_delete on public.profiles;
+create policy profiles_owner_delete on public.profiles 
+  for delete to authenticated
+  using (
+    auth.jwt()->>'user_role' = 'owner'
+    and business_id = auth.get_user_business_id()
+  );
+
+raise notice 'RLS actualizado: profiles';
+
+-- ===============================================
+-- SERVICES
+-- ===============================================
+drop policy if exists services_read_all on public.services;
+create policy services_read_all on public.services 
+  for select to authenticated
+  using (business_id = auth.get_user_business_id());
+
+drop policy if exists services_owner_write on public.services;
+create policy services_owner_write on public.services 
+  for all to authenticated
+  using (
+    auth.jwt()->>'user_role' = 'owner'
+    and business_id = auth.get_user_business_id()
+  )
+  with check (
+    auth.jwt()->>'user_role' = 'owner'
+    and business_id = auth.get_user_business_id()
+  );
+
+raise notice 'RLS actualizado: services';
+
+-- ===============================================
+-- APPOINTMENTS
+-- ===============================================
+drop policy if exists appts_owner_all on public.appointments;
+create policy appts_owner_all on public.appointments 
+  for all to authenticated
+  using (
+    auth.jwt()->>'user_role' = 'owner'
+    and business_id = auth.get_user_business_id()
+  )
+  with check (
+    auth.jwt()->>'user_role' = 'owner'
+    and business_id = auth.get_user_business_id()
+  );
+
+drop policy if exists appts_lead_read on public.appointments;
+create policy appts_lead_read on public.appointments 
+  for select to authenticated
+  using (
+    business_id = auth.get_user_business_id()
+    and exists (
+      select 1 from public.profiles p 
+      where p.id = appointments.profile_id 
+        and p.phone_number = (auth.jwt()->>'phone_number')
+    )
+  );
+
+drop policy if exists appts_lead_insert on public.appointments;
+create policy appts_lead_insert on public.appointments 
+  for insert to authenticated
+  with check (
+    business_id = auth.get_user_business_id()
+    and exists (
+      select 1 from public.profiles p 
+      where p.id = appointments.profile_id 
+        and p.phone_number = (auth.jwt()->>'phone_number')
+    )
+  );
+
+drop policy if exists appts_lead_update on public.appointments;
+create policy appts_lead_update on public.appointments 
+  for update to authenticated
+  using (
+    business_id = auth.get_user_business_id()
+    and exists (
+      select 1 from public.profiles p 
+      where p.id = appointments.profile_id 
+        and p.phone_number = (auth.jwt()->>'phone_number')
+    )
+  )
+  with check (
+    business_id = auth.get_user_business_id()
+    and exists (
+      select 1 from public.profiles p 
+      where p.id = appointments.profile_id 
+        and p.phone_number = (auth.jwt()->>'phone_number')
+    )
+  );
+
+raise notice 'RLS actualizado: appointments';
+
+-- ===============================================
+-- INVENTORY
+-- ===============================================
+drop policy if exists inventory_read_all on public.inventory;
+create policy inventory_read_all on public.inventory 
+  for select to authenticated
+  using (business_id = auth.get_user_business_id());
+
+drop policy if exists inventory_owner_write on public.inventory;
+create policy inventory_owner_write on public.inventory 
+  for all to authenticated
+  using (
+    auth.jwt()->>'user_role' = 'owner'
+    and business_id = auth.get_user_business_id()
+  )
+  with check (
+    auth.jwt()->>'user_role' = 'owner'
+    and business_id = auth.get_user_business_id()
+  );
+
+raise notice 'RLS actualizado: inventory';
+
+-- ===============================================
+-- KNOWLEDGE_BASE
+-- ===============================================
+drop policy if exists kb_read_all on public.knowledge_base;
+create policy kb_read_all on public.knowledge_base 
+  for select to authenticated
+  using (business_id = auth.get_user_business_id());
+
+drop policy if exists kb_owner_write on public.knowledge_base;
+create policy kb_owner_write on public.knowledge_base 
+  for all to authenticated
+  using (
+    auth.jwt()->>'user_role' = 'owner'
+    and business_id = auth.get_user_business_id()
+  )
+  with check (
+    auth.jwt()->>'user_role' = 'owner'
+    and business_id = auth.get_user_business_id()
+  );
+
+raise notice 'RLS actualizado: knowledge_base';
+
+-- ===============================================
+-- CROSS_SELL_RULES
+-- ===============================================
+drop policy if exists crosssell_read_all on public.cross_sell_rules;
+create policy crosssell_read_all on public.cross_sell_rules 
+  for select to authenticated
+  using (business_id = auth.get_user_business_id());
+
+drop policy if exists crosssell_owner_write on public.cross_sell_rules;
+create policy crosssell_owner_write on public.cross_sell_rules 
+  for all to authenticated
+  using (
+    auth.jwt()->>'user_role' = 'owner'
+    and business_id = auth.get_user_business_id()
+  )
+  with check (
+    auth.jwt()->>'user_role' = 'owner'
+    and business_id = auth.get_user_business_id()
+  );
+
+raise notice 'RLS actualizado: cross_sell_rules';
+
+-- ===============================================
+-- WAITLISTS
+-- ===============================================
+drop policy if exists waitlists_owner_all on public.waitlists;
+create policy waitlists_owner_all on public.waitlists 
+  for all to authenticated
+  using (
+    auth.jwt()->>'user_role' = 'owner'
+    and business_id = auth.get_user_business_id()
+  )
+  with check (
+    auth.jwt()->>'user_role' = 'owner'
+    and business_id = auth.get_user_business_id()
+  );
+
+drop policy if exists waitlists_lead_read on public.waitlists;
+create policy waitlists_lead_read on public.waitlists 
+  for select to authenticated
+  using (
+    business_id = auth.get_user_business_id()
+    and exists (
+      select 1 from public.profiles p 
+      where p.id = waitlists.profile_id 
+        and p.phone_number = (auth.jwt()->>'phone_number')
+    )
+  );
+
+drop policy if exists waitlists_lead_insert on public.waitlists;
+create policy waitlists_lead_insert on public.waitlists 
+  for insert to authenticated
+  with check (
+    business_id = auth.get_user_business_id()
+    and exists (
+      select 1 from public.profiles p 
+      where p.id = waitlists.profile_id 
+        and p.phone_number = (auth.jwt()->>'phone_number')
+    )
+  );
+
+drop policy if exists waitlists_lead_update on public.waitlists;
+create policy waitlists_lead_update on public.waitlists 
+  for update to authenticated
+  using (
+    business_id = auth.get_user_business_id()
+    and exists (
+      select 1 from public.profiles p 
+      where p.id = waitlists.profile_id 
+        and p.phone_number = (auth.jwt()->>'phone_number')
+    )
+  )
+  with check (
+    business_id = auth.get_user_business_id()
+    and exists (
+      select 1 from public.profiles p 
+      where p.id = waitlists.profile_id 
+        and p.phone_number = (auth.jwt()->>'phone_number')
+    )
+  );
+
+raise notice 'RLS actualizado: waitlists';
+
+-- ===============================================
+-- AUDIT_LOGS
+-- ===============================================
+drop policy if exists audit_owner_read on public.audit_logs;
+create policy audit_owner_read on public.audit_logs 
+  for select to authenticated
+  using (
+    auth.jwt()->>'user_role' = 'owner'
+    and business_id = auth.get_user_business_id()
+  );
+
+drop policy if exists audit_insert_all on public.audit_logs;
+create policy audit_insert_all on public.audit_logs 
+  for insert to authenticated
+  with check (business_id = auth.get_user_business_id());
+
+raise notice 'RLS actualizado: audit_logs';
+
+-- ===============================================
+-- NOTIFICATIONS_QUEUE
+-- ===============================================
+drop policy if exists nq_owner_read on public.notifications_queue;
+create policy nq_owner_read on public.notifications_queue 
+  for select to authenticated
+  using (
+    auth.jwt()->>'user_role' = 'owner'
+    and business_id = auth.get_user_business_id()
+  );
+
+drop policy if exists nq_insert_all on public.notifications_queue;
+create policy nq_insert_all on public.notifications_queue 
+  for insert to authenticated
+  with check (business_id = auth.get_user_business_id());
+
+raise notice 'RLS actualizado: notifications_queue';
+
+-- ===============================================
+-- RESOURCES
+-- ===============================================
+drop policy if exists resources_read_all on public.resources;
+create policy resources_read_all on public.resources 
+  for select to authenticated
+  using (business_id = auth.get_user_business_id());
+
+drop policy if exists resources_owner_write on public.resources;
+create policy resources_owner_write on public.resources 
+  for all to authenticated
+  using (
+    auth.jwt()->>'user_role' = 'owner'
+    and business_id = auth.get_user_business_id()
+  )
+  with check (
+    auth.jwt()->>'user_role' = 'owner'
+    and business_id = auth.get_user_business_id()
+  );
+
+raise notice 'RLS actualizado: resources';
+
+-- ===============================================
+-- APPOINTMENT_RESOURCES
+-- ===============================================
+drop policy if exists ar_read_owner on public.appointment_resources;
+drop policy if exists ar_insert_all on public.appointment_resources;
+
+create policy ar_read_scoped on public.appointment_resources
+  for select to authenticated
+  using (
+    business_id = auth.get_user_business_id()
+    and (
+      auth.jwt()->>'user_role' = 'owner'
+      or exists (
+        select 1
+        from public.appointments a
+        join public.profiles p on p.id = a.profile_id
+        where a.id = appointment_resources.appointment_id
+          and a.business_id = auth.get_user_business_id()
+          and p.phone_number = (auth.jwt()->>'phone_number')
+      )
+    )
+  );
+
+create policy ar_owner_manage on public.appointment_resources
+  for all to authenticated
+  using (
+    auth.jwt()->>'user_role' = 'owner'
+    and business_id = auth.get_user_business_id()
+  )
+  with check (
+    auth.jwt()->>'user_role' = 'owner'
+    and business_id = auth.get_user_business_id()
+  );
+
+raise notice 'RLS actualizado: appointment_resources';
+
+-- ===============================================
+-- SERVICE_RESOURCE_REQUIREMENTS
+-- ===============================================
+drop policy if exists srr_read_all on public.service_resource_requirements;
+create policy srr_read_all on public.service_resource_requirements 
+  for select to authenticated
+  using (business_id = auth.get_user_business_id());
+
+drop policy if exists srr_owner_write on public.service_resource_requirements;
+create policy srr_owner_write on public.service_resource_requirements 
+  for all to authenticated
+  using (
+    auth.jwt()->>'user_role' = 'owner'
+    and business_id = auth.get_user_business_id()
+  )
+  with check (
+    auth.jwt()->>'user_role' = 'owner'
+    and business_id = auth.get_user_business_id()
+  );
+
+raise notice 'RLS actualizado: service_resource_requirements';
+
+-- ===============================================
+-- RESOURCE_BLOCKS
+-- ===============================================
+drop policy if exists rb_read_all on public.resource_blocks;
+create policy rb_read_all on public.resource_blocks 
+  for select to authenticated
+  using (business_id = auth.get_user_business_id());
+
+drop policy if exists rb_owner_write on public.resource_blocks;
+create policy rb_owner_write on public.resource_blocks 
+  for all to authenticated
+  using (
+    auth.jwt()->>'user_role' = 'owner'
+    and business_id = auth.get_user_business_id()
+  )
+  with check (
+    auth.jwt()->>'user_role' = 'owner'
+    and business_id = auth.get_user_business_id()
+  );
+
+raise notice 'RLS actualizado: resource_blocks';
+
+-- ===============================================
+-- KNOWLEDGE_SUGGESTIONS
+-- ===============================================
+drop policy if exists ks_insert_authenticated on public.knowledge_suggestions;
+create policy ks_insert_authenticated on public.knowledge_suggestions 
+  for insert to authenticated
+  with check (business_id = auth.get_user_business_id());
+
+drop policy if exists ks_read_own on public.knowledge_suggestions;
+create policy ks_read_own on public.knowledge_suggestions 
+  for select to authenticated
+  using (
+    business_id = auth.get_user_business_id()
+    and (
+      auth.jwt()->>'user_role' = 'owner'
+      or exists (
+        select 1 from public.profiles p 
+        where p.id = knowledge_suggestions.profile_id 
+          and p.phone_number = (auth.jwt()->>'phone_number')
+      )
+    )
+  );
+
+drop policy if exists ks_owner_manage on public.knowledge_suggestions;
+create policy ks_owner_manage on public.knowledge_suggestions 
+  for all to authenticated
+  using (
+    auth.jwt()->>'user_role' = 'owner'
+    and business_id = auth.get_user_business_id()
+  )
+  with check (
+    auth.jwt()->>'user_role' = 'owner'
+    and business_id = auth.get_user_business_id()
+  );
+
+raise notice 'RLS actualizado: knowledge_suggestions';
+
+commit;
+
+raise notice '========================================';
+raise notice 'Migración 0201_update_rls_multitenancy completada';
+raise notice 'Todas las políticas RLS actualizadas para multitenancy';
+raise notice '========================================';

--- a/supabase/migrations/0202_update_functions_multitenancy.sql
+++ b/supabase/migrations/0202_update_functions_multitenancy.sql
@@ -1,0 +1,594 @@
+-- ===============================================
+-- Migration: 0202_update_functions_multitenancy.sql
+-- Purpose: Actualizar funciones RPC para multitenancy
+-- Dependencies: 0200_add_multitenancy.sql, 0201_update_rls_multitenancy.sql
+-- ===============================================
+
+begin;
+
+-- ===============================================
+-- get_available_slots
+-- ===============================================
+create or replace function public.get_available_slots(
+    p_service_id uuid,
+    p_start timestamptz,
+    p_end timestamptz,
+    p_step_minutes int default 15
+)
+returns table(slot_start timestamptz, slot_end timestamptz)
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+declare
+    v_dur int;
+    v_cursor timestamptz;
+    v_role text;
+    v_business_id uuid;
+begin
+    v_business_id := auth.get_user_business_id();
+    v_role := auth.jwt()->>'user_role';
+
+    if v_business_id is null then
+        raise exception 'Business context not found for current user';
+    end if;
+
+    if v_role not in ('owner', 'lead') then
+        raise exception 'Insufficient privileges for role %', coalesce(v_role, 'unknown');
+    end if;
+
+    select duration_minutes into v_dur 
+    from public.services 
+    where id = p_service_id
+      and business_id = v_business_id;
+    
+    if v_dur is null then
+        raise exception 'Service not found or access denied';
+    end if;
+    
+    if p_start >= p_end then
+        raise exception 'Invalid time window';
+    end if;
+
+    v_cursor := p_start;
+    while v_cursor + (v_dur || ' minutes')::interval <= p_end loop
+        if not exists (
+            select 1
+            from public.appointments a
+            where a.service_id = p_service_id
+              and a.business_id = v_business_id
+              and a.status = 'confirmed'
+              and tstzrange(a.start_time, a.end_time, '[)') && 
+                  tstzrange(v_cursor, v_cursor + (v_dur || ' minutes')::interval, '[)')
+        ) then
+            slot_start := v_cursor;
+            slot_end := v_cursor + (v_dur || ' minutes')::interval;
+            return next;
+        end if;
+        v_cursor := v_cursor + make_interval(mins => p_step_minutes);
+    end loop;
+end;
+$$;
+
+raise notice 'Función get_available_slots actualizada';
+
+-- ===============================================
+-- get_available_slots_with_resources (CORREGIDA)
+-- ===============================================
+create or replace function public.get_available_slots_with_resources(
+    p_service_id uuid,
+    p_start timestamptz,
+    p_end timestamptz,
+    p_step_minutes int default 15
+)
+returns table(slot_start timestamptz, slot_end timestamptz, available_resources jsonb)
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+declare
+    v_dur int;
+    v_cursor timestamptz;
+    v_slot_end timestamptz;
+    v_required_resources uuid[];
+    v_available_resources jsonb;
+    v_resource_json jsonb;
+    v_all_available boolean;
+    v_role text;
+    v_business_id uuid;
+    i int;
+begin
+    v_business_id := auth.get_user_business_id();
+    v_role := auth.jwt()->>'user_role';
+    
+    if v_business_id is null then
+        raise exception 'Business context not found for current user';
+    end if;
+    
+    if v_role not in ('owner', 'lead') then
+        raise exception 'Insufficient privileges for role %', coalesce(v_role, 'unknown');
+    end if;
+
+    select duration_minutes into v_dur 
+    from public.services 
+    where id = p_service_id
+      and business_id = v_business_id;
+    
+    if v_dur is null then
+        raise exception 'Service not found or access denied';
+    end if;
+    
+    if p_start >= p_end then
+        raise exception 'Invalid time window';
+    end if;
+
+    select array_agg(resource_id)
+    into v_required_resources
+    from public.service_resource_requirements
+    where service_id = p_service_id
+      and business_id = v_business_id
+      and is_optional = false;
+
+    if v_required_resources is null or array_length(v_required_resources, 1) = 0 then
+        return query 
+        select * from public.get_available_slots(p_service_id, p_start, p_end, p_step_minutes);
+        return;
+    end if;
+
+    v_cursor := p_start;
+    while v_cursor + (v_dur || ' minutes')::interval <= p_end loop
+        v_slot_end := v_cursor + (v_dur || ' minutes')::interval;
+        v_all_available := true;
+        v_available_resources := '[]'::jsonb;
+
+        for i in 1..array_length(v_required_resources, 1) loop
+            if exists (
+                select 1
+                from public.resource_blocks rb
+                where rb.resource_id = v_required_resources[i]
+                  and rb.business_id = v_business_id
+                  and tstzrange(rb.start_time, rb.end_time, '[)') && 
+                      tstzrange(v_cursor, v_slot_end, '[)')
+            ) then
+                v_all_available := false;
+                exit;
+            end if;
+            
+            if exists (
+                select 1
+                from public.appointment_resources ar
+                join public.appointments a on a.id = ar.appointment_id
+                where ar.resource_id = v_required_resources[i]
+                  and ar.business_id = v_business_id
+                  and a.business_id = v_business_id
+                  and a.status = 'confirmed'
+                  and tstzrange(a.start_time, a.end_time, '[)') &&
+                      tstzrange(v_cursor, v_slot_end, '[)')
+            ) then
+                v_all_available := false;
+                exit;
+            end if;
+            
+            select jsonb_build_object(
+                'resource_id', r.id,
+                'name', r.name,
+                'type', r.type
+            )
+            into v_resource_json
+            from public.resources r
+            where r.id = v_required_resources[i]
+              and r.business_id = v_business_id;
+            
+            if v_resource_json is null then
+                v_all_available := false;
+                exit;
+            end if;
+            
+            v_available_resources := v_available_resources || jsonb_build_array(v_resource_json);
+        end loop;
+
+        if v_all_available then
+            slot_start := v_cursor;
+            slot_end := v_slot_end;
+            available_resources := v_available_resources;
+            return next;
+        end if;
+
+        v_cursor := v_cursor + make_interval(mins => p_step_minutes);
+    end loop;
+end;
+$$;
+
+raise notice 'Función get_available_slots_with_resources actualizada (CORREGIDA)';
+
+-- ===============================================
+-- confirm_appointment_with_resources
+-- ===============================================
+create or replace function public.confirm_appointment_with_resources(
+    p_appointment_id uuid,
+    p_strategy text default 'first_available'
+)
+returns jsonb 
+language plpgsql 
+security definer 
+set search_path = public 
+as $$
+declare 
+    v_appointment record;
+    v_required record;
+    v_assigned_resources jsonb := '[]'::jsonb;
+    v_business_id uuid;
+begin
+    v_business_id := auth.get_user_business_id();
+    
+    if v_business_id is null then
+        raise exception 'Business context not found for current user';
+    end if;
+    
+    select * into v_appointment 
+    from public.appointments 
+    where id = p_appointment_id 
+      and business_id = v_business_id
+    for update;
+    
+    if not found then 
+        raise exception 'Appointment not found or access denied';
+    end if;
+    
+    if v_appointment.status = 'confirmed' then 
+        raise exception 'Appointment already confirmed';
+    end if;
+
+    for v_required in 
+        select 
+            srr.resource_id, 
+            srr.quantity, 
+            r.name, 
+            r.type 
+        from public.service_resource_requirements srr
+        join public.resources r on r.id = srr.resource_id
+        where srr.service_id = v_appointment.service_id
+          and srr.business_id = v_business_id
+          and r.business_id = v_business_id
+          and srr.is_optional = false
+    loop
+        if exists (
+            select 1
+            from public.resource_blocks rb
+            where rb.resource_id = v_required.resource_id
+              and rb.business_id = v_business_id
+              and tstzrange(rb.start_time, rb.end_time, '[)') && 
+                  tstzrange(v_appointment.start_time, v_appointment.end_time, '[)')
+        ) then
+            raise exception 'Resource % (%) is blocked for the requested time slot', 
+                v_required.name, v_required.type;
+        end if;
+        
+        if exists (
+            select 1
+            from public.appointment_resources ar
+            join public.appointments a on a.id = ar.appointment_id
+            where ar.resource_id = v_required.resource_id
+              and ar.business_id = v_business_id
+              and a.business_id = v_business_id
+              and a.status = 'confirmed'
+              and a.id != p_appointment_id
+              and tstzrange(a.start_time, a.end_time, '[)') &&
+                  tstzrange(v_appointment.start_time, v_appointment.end_time, '[)')
+        ) then
+            raise exception 'Resource % (%) is not available for the requested time slot',
+                v_required.name, v_required.type;
+        end if;
+
+        insert into public.appointment_resources (appointment_id, resource_id, business_id)
+        values (p_appointment_id, v_required.resource_id, v_business_id)
+        on conflict do nothing;
+        
+        v_assigned_resources := v_assigned_resources || jsonb_build_array(jsonb_build_object(
+            'resource_id', v_required.resource_id,
+            'name', v_required.name,
+            'type', v_required.type
+        ));
+    end loop;
+
+    update public.appointments 
+    set status = 'confirmed', updated_at = now() 
+    where id = p_appointment_id;
+    
+    return jsonb_build_object(
+        'appointment_id', p_appointment_id,
+        'status', 'confirmed',
+        'assigned_resources', v_assigned_resources
+    );
+end $$;
+
+raise notice 'Función confirm_appointment_with_resources actualizada';
+
+-- ===============================================
+-- decrement_inventory
+-- ===============================================
+create or replace function public.decrement_inventory(
+    p_sku text,
+    p_qty int
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare 
+    v_item record;
+    v_business_id uuid;
+begin
+    v_business_id := auth.get_user_business_id();
+    
+    if v_business_id is null then
+        raise exception 'Business context not found for current user';
+    end if;
+    
+    if p_qty is null or p_qty <= 0 then 
+        raise exception 'Quantity must be positive, got: %', p_qty;
+    end if;
+    
+    select * into v_item 
+    from public.inventory 
+    where sku = p_sku 
+      and business_id = v_business_id
+    for update;
+    
+    if not found then 
+        raise exception 'SKU % not found in your business', p_sku;
+    end if;
+    
+    if v_item.quantity < p_qty then 
+        raise exception 'Insufficient stock for % (have %, need %)', 
+            p_sku, v_item.quantity, p_qty;
+    end if;
+    
+    update public.inventory 
+    set quantity = quantity - p_qty, updated_at = now() 
+    where id = v_item.id;
+end $$;
+
+raise notice 'Función decrement_inventory actualizada';
+
+-- ===============================================
+-- refresh_metrics_historical
+-- ===============================================
+create or replace function public.refresh_metrics_historical()
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+    refresh materialized view public.metrics_historical;
+end $$;
+
+raise notice 'Función refresh_metrics_historical mantiene su implementación';
+
+-- ===============================================
+-- Funciones de KB (Knowledge Base)
+-- ===============================================
+
+create or replace function public.search_knowledge_base(
+    p_query text,
+    p_similarity_threshold double precision default 0.20,
+    p_limit int default 5
+)
+returns table(id uuid, category text, question text, answer text, similarity double precision)
+language sql
+stable
+as $$
+select
+    kb.id, kb.category, kb.question, kb.answer,
+    similarity(kb.question_normalized, public.norm_txt(p_query)) as sim
+from public.knowledge_base kb
+where kb.business_id = auth.get_user_business_id()
+  and similarity(kb.question_normalized, public.norm_txt(p_query)) > p_similarity_threshold
+order by sim desc
+limit p_limit
+$$;
+
+raise notice 'Función search_knowledge_base actualizada';
+
+create or replace function public.search_knowledge_by_keywords(
+    p_keywords text[],
+    p_limit int default 5
+)
+returns table(id uuid, category text, question text, answer text, keyword_matches int)
+language sql
+stable
+as $$
+select
+    kb.id, kb.category, kb.question, kb.answer,
+    (
+        select count(*)
+        from unnest(p_keywords) as kw
+        where kb.question_normalized ilike ('%' || public.norm_txt(kw) || '%')
+           or kb.answer_normalized ilike ('%' || public.norm_txt(kw) || '%')
+    )::int as keyword_matches
+from public.knowledge_base kb
+where kb.business_id = auth.get_user_business_id()
+  and exists (
+    select 1
+    from unnest(p_keywords) as kw
+    where kb.question_normalized ilike ('%' || public.norm_txt(kw) || '%')
+       or kb.answer_normalized ilike ('%' || public.norm_txt(kw) || '%')
+)
+order by keyword_matches desc, kb.id
+limit p_limit
+$$;
+
+raise notice 'Función search_knowledge_by_keywords actualizada';
+
+create or replace function public.search_knowledge_hybrid(
+    p_query text,
+    p_similarity_threshold double precision default 0.15,
+    p_limit int default 5,
+    p_category text default null
+)
+returns table(id uuid, category text, question text, answer text, relevance_score double precision, match_type text)
+language plpgsql
+stable
+as $$
+declare
+    vq text;
+    v_keywords text[];
+    v_business_id uuid;
+begin
+    v_business_id := auth.get_user_business_id();
+    vq := public.norm_txt(p_query);
+    
+    select array_agg(w) into v_keywords
+    from (
+        select word as w
+        from regexp_split_to_table(vq, '\\s+') as word
+        where length(word) >= 3
+    ) q;
+
+    return query
+    with base as (
+        select
+            kb.id as kb_id,
+            kb.category as kb_category,
+            kb.question as kb_question,
+            kb.answer as kb_answer,
+            kb.question_normalized as kb_question_normalized,
+            kb.answer_normalized as kb_answer_normalized
+        from public.knowledge_base kb
+        where kb.business_id = v_business_id
+          and (p_category is null or kb.category = p_category)
+    ),
+    similarity_results as (
+        select
+            b.kb_id, b.kb_category, b.kb_question, b.kb_answer,
+            similarity(b.kb_question_normalized, vq) * 100.0 as score,
+            'similarity'::text as match_type
+        from base b
+        where similarity(b.kb_question_normalized, vq) > p_similarity_threshold
+    ),
+    keyword_results as (
+        select
+            b.kb_id, b.kb_category, b.kb_question, b.kb_answer,
+            (
+                select (sum(case when b.kb_question_normalized ilike ('%' || kw || '%') then 1 else 0 end) * 24.0)
+                     + (sum(case when b.kb_answer_normalized ilike ('%' || kw || '%') then 1 else 0 end) * 16.0)
+                from unnest(coalesce(v_keywords, array[]::text[])) as kw
+            ) as score,
+            'keywords'::text as match_type
+        from base b
+        where exists (
+            select 1
+            from unnest(coalesce(v_keywords, array[]::text[])) as kw
+            where b.kb_question_normalized ilike ('%' || kw || '%')
+               or b.kb_answer_normalized ilike ('%' || kw || '%')
+        )
+    ),
+    combined as (
+        select * from similarity_results
+        union all
+        select * from keyword_results
+    )
+    select
+        c.kb_id, c.kb_category, c.kb_question, c.kb_answer,
+        max(c.score) as relevance_score,
+        string_agg(distinct c.match_type, '+' order by c.match_type) as match_type
+    from combined c
+    group by c.kb_id, c.kb_category, c.kb_question, c.kb_answer
+    order by relevance_score desc
+    limit p_limit;
+end
+$$;
+
+raise notice 'Función search_knowledge_hybrid actualizada';
+
+create or replace function public.get_related_questions(
+    p_question_id uuid,
+    p_limit int default 3
+)
+returns table(id uuid, category text, question text, similarity double precision)
+language sql
+stable
+as $$
+select
+    kb2.id, kb2.category, kb2.question,
+    similarity(kb1.question_normalized, kb2.question_normalized) as sim
+from public.knowledge_base kb1
+cross join public.knowledge_base kb2
+where kb1.id = p_question_id
+  and kb2.id != p_question_id
+  and kb1.business_id = auth.get_user_business_id()
+  and kb2.business_id = auth.get_user_business_id()
+  and similarity(kb1.question_normalized, kb2.question_normalized) > 0.15
+order by sim desc
+limit p_limit
+$$;
+
+raise notice 'Función get_related_questions actualizada';
+
+create or replace function public.increment_kb_view_count_guarded(
+    p_question_id uuid,
+    p_phone_hash text
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    v_should_increment boolean := false;
+    v_last_view timestamptz;
+    v_lock_id bigint;
+    v_business_id uuid;
+begin
+    v_business_id := auth.get_user_business_id();
+    
+    if v_business_id is null then
+        raise exception 'Business context not found for current user';
+    end if;
+    
+    if not exists (
+        select 1 from public.knowledge_base 
+        where id = p_question_id 
+          and business_id = v_business_id
+    ) then
+        raise exception 'Question not found or access denied';
+    end if;
+    
+    v_lock_id := hashtext(p_question_id::text || coalesce(p_phone_hash, ''));
+    perform pg_advisory_xact_lock(v_lock_id);
+
+    select last_view into v_last_view
+    from public.kb_views_footprint
+    where kb_id = p_question_id and phone_hash = p_phone_hash;
+
+    if v_last_view is null then
+        v_should_increment := true;
+    elsif now() - v_last_view > interval '60 seconds' then
+        v_should_increment := true;
+    end if;
+
+    insert into public.kb_views_footprint(kb_id, phone_hash, last_view)
+    values (p_question_id, p_phone_hash, now())
+    on conflict (kb_id, phone_hash)
+    do update set last_view = now();
+
+    if v_should_increment then
+        update public.knowledge_base
+        set view_count = view_count + 1
+        where id = p_question_id
+          and business_id = v_business_id;
+    end if;
+end $$;
+
+raise notice 'Función increment_kb_view_count_guarded actualizada';
+
+commit;
+
+raise notice '========================================';
+raise notice 'Migración 0202_update_functions_multitenancy completada';
+raise notice 'Todas las funciones actualizadas con business_id';
+raise notice '========================================';

--- a/supabase/migrations/0203_business_settings.sql
+++ b/supabase/migrations/0203_business_settings.sql
@@ -1,0 +1,153 @@
+-- ===============================================
+-- Migration: 0203_business_settings.sql
+-- Purpose: Tabla de configuración personalizable por negocio
+-- Dependencies: 0200_add_multitenancy.sql
+-- ===============================================
+
+begin;
+
+create table if not exists public.business_settings (
+  id uuid primary key default gen_random_uuid(),
+  business_id uuid not null references public.businesses(id) on delete cascade,
+  setting_key text not null,
+  setting_value jsonb not null,
+  description text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint business_settings_unique_key unique (business_id, setting_key)
+);
+
+comment on table public.business_settings is 
+  'Configuración personalizable por negocio: horarios, políticas, precios, etc.';
+comment on column public.business_settings.setting_key is 
+  'Clave de configuración: business_hours, cancellation_policy, pricing_rules, etc.';
+comment on column public.business_settings.setting_value is 
+  'Valor en formato JSON con la configuración específica';
+
+create index if not exists idx_business_settings_business 
+  on public.business_settings(business_id);
+create index if not exists idx_business_settings_key 
+  on public.business_settings(business_id, setting_key);
+
+raise notice 'Tabla business_settings creada';
+
+drop trigger if exists trg_upd_business_settings on public.business_settings;
+create trigger trg_upd_business_settings 
+  before update on public.business_settings 
+  for each row 
+  execute function public.set_updated_at();
+
+raise notice 'Trigger para business_settings creado';
+
+alter table public.business_settings enable row level security;
+
+drop policy if exists bs_read on public.business_settings;
+create policy bs_read on public.business_settings
+  for select to authenticated
+  using (business_id = auth.get_user_business_id());
+
+drop policy if exists bs_owner_write on public.business_settings;
+create policy bs_owner_write on public.business_settings
+  for all to authenticated
+  using (
+    auth.jwt()->>'user_role' = 'owner'
+    and business_id = auth.get_user_business_id()
+  )
+  with check (
+    auth.jwt()->>'user_role' = 'owner'
+    and business_id = auth.get_user_business_id()
+  );
+
+raise notice 'RLS configurado para business_settings';
+
+create or replace function public.is_within_business_hours(
+  p_business_id uuid,
+  p_timestamp timestamptz
+)
+returns boolean
+language plpgsql
+stable
+as $$
+declare
+  v_settings jsonb;
+  v_day_index int;
+  v_day_key text;
+  v_day_config jsonb;
+  v_hour time;
+  v_timezone text;
+  v_date date;
+  v_holidays jsonb;
+  v_days text[] := array['sunday','monday','tuesday','wednesday','thursday','friday','saturday'];
+begin
+  select setting_value into v_settings
+  from public.business_settings
+  where business_id = p_business_id
+    and setting_key = 'business_hours';
+  
+  if v_settings is null then
+    return extract(hour from p_timestamp) between 9 and 20
+       and extract(dow from p_timestamp) between 1 and 6;
+  end if;
+  
+  v_timezone := coalesce(v_settings->>'timezone', 'Europe/Madrid');
+  v_holidays := v_settings->'holidays';
+  v_date := (p_timestamp at time zone v_timezone)::date;
+  
+  if v_holidays is not null and v_holidays ? v_date::text then
+    return false;
+  end if;
+  
+  v_day_index := extract(dow from p_timestamp at time zone v_timezone)::int;
+  if v_day_index < 0 or v_day_index >= array_length(v_days, 1) then
+    return false;
+  end if;
+
+  v_day_key := v_days[v_day_index + 1];
+  v_day_config := v_settings->'schedule'->v_day_key;
+  
+  if v_day_config is null then
+    return false;
+  end if;
+  
+  if coalesce((v_day_config->>'closed')::boolean, false) then
+    return false;
+  end if;
+  
+  v_hour := (p_timestamp at time zone v_timezone)::time;
+  
+  return v_hour >= (v_day_config->>'open')::time
+     and v_hour < (v_day_config->>'close')::time;
+end;
+$$;
+
+comment on function public.is_within_business_hours is
+  'Valida si un timestamp está dentro del horario de negocio configurado. Si no hay configuración, usa horario por defecto (Lun-Sáb 9-20h).';
+
+raise notice 'Función is_within_business_hours creada';
+
+create or replace function public.get_business_setting(
+  p_setting_key text
+)
+returns jsonb
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select setting_value
+  from public.business_settings
+  where business_id = auth.get_user_business_id()
+    and setting_key = p_setting_key
+  limit 1
+$$;
+
+comment on function public.get_business_setting is
+  'Obtiene una configuración específica del negocio del usuario actual';
+
+raise notice 'Función get_business_setting creada';
+
+commit;
+
+raise notice '========================================';
+raise notice 'Migración 0203_business_settings completada';
+raise notice '========================================';

--- a/supabase/migrations/0204_add_validations_audit.sql
+++ b/supabase/migrations/0204_add_validations_audit.sql
@@ -1,0 +1,187 @@
+-- ===============================================
+-- Migration: 0204_add_validations_audit.sql
+-- Purpose: Agregar validaciones de negocio y auditoría de cancelaciones
+-- Dependencies: 0200_add_multitenancy.sql, 0201_update_rls_multitenancy.sql, 0202_update_functions_multitenancy.sql, 0203_business_settings.sql
+-- ===============================================
+
+begin;
+
+alter table public.appointments 
+  drop constraint if exists appt_future_only;
+
+alter table public.appointments 
+  add constraint appt_future_only 
+  check (start_time >= current_timestamp - interval '1 hour');
+
+comment on constraint appt_future_only on public.appointments is
+  'Las citas deben agendarse para el futuro (con 1 hora de margen)';
+
+raise notice '[1/6] Validación: citas futuras';
+
+alter table public.services 
+  drop constraint if exists services_price_reasonable;
+
+alter table public.services 
+  add constraint services_price_reasonable 
+  check (base_price between 0.01 and 10000);
+
+comment on constraint services_price_reasonable on public.services is
+  'Precio debe estar entre 0.01 y 10,000 para evitar errores';
+
+raise notice '[2/6] Validación: precios de servicios';
+
+alter table public.appointments 
+  add column if not exists cancelled_by uuid references public.profiles(id),
+  add column if not exists cancelled_at timestamptz,
+  add column if not exists cancellation_reason text;
+
+comment on column public.appointments.cancelled_by is 'Usuario que canceló la cita';
+comment on column public.appointments.cancelled_at is 'Fecha y hora de cancelación';
+comment on column public.appointments.cancellation_reason is 'Motivo de cancelación';
+
+create index if not exists idx_appointments_cancelled 
+  on public.appointments(cancelled_at desc) 
+  where cancelled_at is not null;
+
+raise notice '[3/6] Columnas de auditoría agregadas';
+
+create or replace function public.log_cancellation() 
+returns trigger 
+language plpgsql 
+security definer 
+set search_path = public
+as $$
+declare
+  v_user_id uuid;
+  v_claims jsonb;
+begin
+  if new.status = 'cancelled' and old.status != 'cancelled' then
+    v_claims := auth.jwt();
+
+    begin
+      if v_claims is not null and v_claims ? 'sub' then
+        v_user_id := nullif(v_claims->>'sub', '')::uuid;
+      else
+        v_user_id := null;
+      end if;
+    exception when others then
+      v_user_id := null;
+    end;
+
+    new.cancelled_at := now();
+    new.cancelled_by := v_user_id;
+    
+    if new.cancellation_reason is null or trim(new.cancellation_reason) = '' then
+      new.cancellation_reason := 'No especificada';
+    end if;
+    
+    insert into public.audit_logs (
+      business_id,
+      profile_id,
+      action,
+      payload
+    ) values (
+      new.business_id,
+      v_user_id,
+      'appointment_cancelled',
+      jsonb_build_object(
+        'appointment_id', new.id,
+        'service_id', new.service_id,
+        'start_time', new.start_time,
+        'cancelled_at', now(),
+        'reason', new.cancellation_reason
+      )
+    );
+  end if;
+  
+  return new;
+end;
+$$;
+
+drop trigger if exists on_appointment_cancelled on public.appointments;
+create trigger on_appointment_cancelled
+  before update on public.appointments
+  for each row
+  execute function public.log_cancellation();
+
+comment on function public.log_cancellation is
+  'Registra automáticamente quién canceló una cita y cuándo';
+
+raise notice '[4/6] Trigger de auditoría de cancelaciones creado';
+
+alter table public.appointments 
+  add column if not exists deposit_required numeric(10,2) default 0 check (deposit_required >= 0),
+  add column if not exists deposit_paid numeric(10,2) default 0 check (deposit_paid >= 0);
+
+comment on column public.appointments.deposit_required is 'Monto de depósito requerido';
+comment on column public.appointments.deposit_paid is 'Monto de depósito pagado';
+
+alter table public.appointments 
+  drop constraint if exists appt_deposit_not_exceed;
+
+alter table public.appointments 
+  add constraint appt_deposit_not_exceed 
+  check (deposit_paid <= deposit_required);
+
+raise notice '[5/6] Columnas de depósito agregadas';
+
+create or replace function public.calculate_deposit_required()
+returns trigger
+language plpgsql
+as $$
+declare
+  v_service_price numeric(10,2);
+  v_pricing_rules jsonb;
+  v_deposit_threshold numeric(10,2);
+  v_deposit_percentage numeric;
+begin
+  select base_price into v_service_price
+  from public.services
+  where id = new.service_id
+    and business_id = new.business_id;
+  
+  if v_service_price is null then
+    new.deposit_required := 0;
+    return new;
+  end if;
+  
+  select setting_value into v_pricing_rules
+  from public.business_settings
+  where business_id = new.business_id
+    and setting_key = 'pricing_rules';
+  
+  if v_pricing_rules is null then
+    new.deposit_required := 0;
+    return new;
+  end if;
+  
+  v_deposit_threshold := coalesce((v_pricing_rules->>'deposit_required_above')::numeric, 100);
+  v_deposit_percentage := coalesce((v_pricing_rules->>'deposit_percentage')::numeric, 30);
+  
+  if v_service_price >= v_deposit_threshold then
+    new.deposit_required := round((v_service_price * v_deposit_percentage / 100), 2);
+  else
+    new.deposit_required := 0;
+  end if;
+  
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_calculate_deposit on public.appointments;
+create trigger trg_calculate_deposit
+  before insert or update of service_id on public.appointments
+  for each row
+  execute function public.calculate_deposit_required();
+
+comment on function public.calculate_deposit_required is
+  'Calcula automáticamente el depósito requerido basándose en las reglas de pricing del negocio';
+
+raise notice '[6/6] Trigger de cálculo de depósitos creado';
+
+commit;
+
+raise notice '========================================';
+raise notice 'Migración 0204_add_validations_audit completada';
+raise notice 'Validaciones y auditoría implementadas';
+raise notice '========================================';

--- a/supabase/migrations/0205_cleanup_footprints.sql
+++ b/supabase/migrations/0205_cleanup_footprints.sql
@@ -1,0 +1,130 @@
+-- ===============================================
+-- Migration: 0205_cleanup_footprints.sql
+-- Purpose: Limpieza automática de datos antiguos
+-- Dependencies: 0005_feature_kb_search.sql, 0200_add_multitenancy.sql
+-- ===============================================
+
+begin;
+
+create or replace function public.cleanup_old_footprints()
+returns table(deleted_count bigint)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_count bigint;
+begin
+  delete from public.kb_views_footprint 
+  where last_view < now() - interval '2 years';
+  
+  get diagnostics v_count = row_count;
+  
+  raise notice 'Cleanup: % registros borrados de kb_views_footprint', v_count;
+  
+  return query select v_count;
+end $$;
+
+comment on function public.cleanup_old_footprints is
+  'Borra registros de visualizaciones de KB más antiguos de 2 años. Retorna cantidad de registros eliminados.';
+
+raise notice 'Función cleanup_old_footprints creada';
+
+create extension if not exists pg_cron;
+
+raise notice 'Extensión pg_cron verificada';
+
+do $$
+begin
+  perform cron.unschedule('cleanup-footprints');
+exception
+  when others then
+    raise notice 'No había job previo, continuando...';
+end $$;
+
+select cron.schedule(
+  'cleanup-footprints',
+  '0 2 1 * *',
+  'select public.cleanup_old_footprints()'
+);
+
+raise notice 'Limpieza automática programada: día 1 de cada mes a las 2 AM';
+
+create or replace function public.check_scheduled_jobs()
+returns table(
+  jobid bigint,
+  schedule text,
+  command text,
+  nodename text,
+  nodeport int,
+  database text,
+  username text,
+  active boolean
+)
+language sql
+stable
+as $$
+  select 
+    jobid,
+    schedule,
+    command,
+    nodename,
+    nodeport,
+    database,
+    username,
+    active
+  from cron.job
+  order by jobid;
+$$;
+
+comment on function public.check_scheduled_jobs is
+  'Lista todos los jobs programados con pg_cron';
+
+raise notice 'Función check_scheduled_jobs creada';
+
+create or replace function public.check_job_history(p_limit int default 20)
+returns table(
+  runid bigint,
+  jobid bigint,
+  job_name text,
+  start_time timestamptz,
+  end_time timestamptz,
+  status text,
+  return_message text
+)
+language sql
+stable
+as $$
+  select 
+    jrd.runid,
+    jrd.jobid,
+    j.jobname as job_name,
+    jrd.start_time,
+    jrd.end_time,
+    jrd.status,
+    jrd.return_message
+  from cron.job_run_details jrd
+  join cron.job j on j.jobid = jrd.jobid
+  order by jrd.start_time desc
+  limit p_limit;
+$$;
+
+comment on function public.check_job_history is
+  'Muestra el historial de ejecuciones de jobs programados';
+
+raise notice 'Función check_job_history creada';
+
+commit;
+
+raise notice '========================================';
+raise notice 'Migración 0205_cleanup_footprints completada';
+raise notice '';
+raise notice 'Para verificar el job programado, ejecuta:';
+raise notice '  select * from public.check_scheduled_jobs();';
+raise notice '';
+raise notice 'Para ver historial de ejecuciones:';
+raise notice '  select * from public.check_job_history();';
+raise notice '';
+raise notice 'Para ejecutar limpieza manualmente:';
+raise notice '  select public.cleanup_old_footprints();';
+raise notice '========================================';

--- a/supabase/migrations/0206_update_views_multitenancy.sql
+++ b/supabase/migrations/0206_update_views_multitenancy.sql
@@ -1,0 +1,181 @@
+-- ===============================================
+-- Migration: 0206_update_views_multitenancy.sql
+-- Purpose: Actualizar vistas materializadas y normales con business_id
+-- Dependencies: 0200_add_multitenancy.sql
+-- ===============================================
+
+begin;
+
+drop materialized view if exists public.metrics_historical cascade;
+
+create materialized view public.metrics_historical as
+select
+    a.business_id,
+    date_trunc('day', a.start_time) as period_day,
+    date_trunc('week', a.start_time) as period_week,
+    date_trunc('month', a.start_time) as period_month,
+    a.service_id,
+    s.name as service_name,
+    count(*) filter (where a.status = 'confirmed') as confirmed_count,
+    count(*) filter (where a.status = 'cancelled') as cancelled_count,
+    count(*) filter (where a.status = 'pending') as pending_count,
+    sum(s.base_price) filter (where a.status = 'confirmed') as confirmed_revenue,
+    avg(s.base_price) filter (where a.status = 'confirmed') as avg_revenue
+from public.appointments a
+join public.services s on s.id = a.service_id
+where a.business_id = s.business_id
+  and a.business_id is not null
+group by a.business_id, period_day, period_week, period_month, a.service_id, s.name;
+
+create index if not exists idx_metrics_hist_business 
+  on public.metrics_historical(business_id);
+create index if not exists idx_metrics_hist_day 
+  on public.metrics_historical(business_id, period_day);
+create index if not exists idx_metrics_hist_week 
+  on public.metrics_historical(business_id, period_week);
+create index if not exists idx_metrics_hist_month 
+  on public.metrics_historical(business_id, period_month);
+create index if not exists idx_metrics_hist_service 
+  on public.metrics_historical(business_id, service_id);
+
+create unique index if not exists uq_metrics_historical
+on public.metrics_historical (
+    business_id,
+    period_day, 
+    period_week, 
+    period_month, 
+    service_id, 
+    service_name
+);
+
+raise notice 'Vista materializada metrics_historical actualizada';
+
+create or replace view public.owner_dashboard_metrics as
+select
+    a.business_id,
+    date_trunc('day', a.start_time) as day,
+    count(*) filter (where a.status = 'confirmed') as confirmed_appointments,
+    sum(s.base_price) filter (where a.status = 'confirmed') as estimated_revenue,
+    (
+        select s2.name
+        from public.services s2
+        join public.appointments a2 on a2.service_id = s2.id 
+        where a2.business_id = a.business_id
+          and s2.business_id = a.business_id
+          and a2.status = 'confirmed'
+          and date_trunc('day', a2.start_time) = date_trunc('day', a.start_time)
+        group by s2.id, s2.name
+        order by count(*) desc
+        limit 1
+    ) as top_service
+from public.appointments a
+join public.services s on s.id = a.service_id and s.business_id = a.business_id
+where a.business_id is not null
+group by a.business_id, day
+order by day desc;
+
+raise notice 'Vista owner_dashboard_metrics actualizada';
+
+create or replace view public.metrics_daily as
+with daily_stats as (
+    select
+        a.business_id,
+        date_trunc('day', a.start_time)::date as day,
+        count(*) filter (where a.status = 'confirmed') as confirmed_today,
+        count(*) filter (where a.status = 'pending') as pending_today,
+        count(*) filter (where a.status = 'cancelled') as cancelled_today,
+        sum(s.base_price) filter (where a.status = 'confirmed') as revenue_today
+    from public.appointments a
+    join public.services s on s.id = a.service_id and s.business_id = a.business_id
+    where a.business_id is not null
+    group by a.business_id, date_trunc('day', a.start_time)::date
+),
+top_service_per_day as (
+    select distinct on (a.business_id, date_trunc('day', a.start_time)::date)
+        a.business_id,
+        date_trunc('day', a.start_time)::date as day,
+        s.name as top_service_today,
+        count(*) as top_service_count
+    from public.appointments a
+    join public.services s on s.id = a.service_id and s.business_id = a.business_id
+    where a.status = 'confirmed'
+      and a.business_id is not null
+    group by a.business_id, date_trunc('day', a.start_time)::date, s.id, s.name
+    order by a.business_id, date_trunc('day', a.start_time)::date, count(*) desc
+)
+select
+    ds.business_id,
+    ds.day, 
+    ds.confirmed_today, 
+    ds.pending_today, 
+    ds.cancelled_today, 
+    ds.revenue_today,
+    coalesce(ts.top_service_today, '') as top_service_today,
+    coalesce(ts.top_service_count, 0) as top_service_count
+from daily_stats ds
+left join top_service_per_day ts 
+  on ts.business_id = ds.business_id 
+  and ts.day = ds.day
+order by ds.business_id, ds.day desc;
+
+raise notice 'Vista metrics_daily actualizada';
+
+create or replace view public.metrics_top_services_global as
+select
+    s.business_id,
+    s.id as service_id,
+    s.name as service_name,
+    count(a.id) as total_appointments,
+    count(a.id) filter (where a.status = 'confirmed') as confirmed_appointments,
+    sum(s.base_price) filter (where a.status = 'confirmed') as total_revenue,
+    avg(s.base_price) filter (where a.status = 'confirmed') as avg_revenue,
+    min(a.start_time) as first_appointment,
+    max(a.start_time) as last_appointment
+from public.services s
+left join public.appointments a on a.service_id = s.id and a.business_id = s.business_id
+where s.business_id is not null
+group by s.business_id, s.id, s.name
+order by s.business_id, confirmed_appointments desc;
+
+raise notice 'Vista metrics_top_services_global actualizada';
+
+create or replace view public.inventory_low_stock as
+select
+    business_id,
+    id, 
+    sku, 
+    name, 
+    quantity, 
+    reorder_threshold, 
+    price,
+    (reorder_threshold - quantity) as units_needed
+from public.inventory
+where quantity <= reorder_threshold
+order by business_id, (reorder_threshold - quantity) desc;
+
+raise notice 'Vista inventory_low_stock actualizada';
+
+create or replace view public.knowledge_popular_questions as
+select
+    business_id,
+    id, 
+    category, 
+    question, 
+    view_count, 
+    created_at
+from public.knowledge_base
+where view_count > 0
+order by business_id, view_count desc, created_at desc;
+
+raise notice 'Vista knowledge_popular_questions actualizada';
+
+refresh materialized view public.metrics_historical;
+
+raise notice 'Vista materializada metrics_historical refrescada';
+
+commit;
+
+raise notice '========================================';
+raise notice 'Migración 0206_update_views_multitenancy completada';
+raise notice 'Todas las vistas actualizadas con business_id';
+raise notice '========================================';

--- a/supabase/migrations/0207_update_seed_multitenancy.sql
+++ b/supabase/migrations/0207_update_seed_multitenancy.sql
@@ -1,0 +1,195 @@
+-- ===============================================
+-- Migration: 0207_update_seed_multitenancy.sql
+-- Purpose: Actualizar datos de prueba con business_id (solo entornos de desarrollo)
+-- Dependencies: 0099_seed_dev.sql, 0200_add_multitenancy.sql
+-- ===============================================
+
+-- Verificación de seguridad
+-- Solo permitir ejecución en bases dev/test/local/staging
+
+do $$
+declare
+    v_db_name text := current_database();
+    v_is_safe boolean;
+begin
+    v_is_safe := v_db_name ilike '%dev%'
+        or v_db_name ilike '%develop%'
+        or v_db_name ilike '%test%'
+        or v_db_name ilike '%local%'
+        or v_db_name ilike '%staging%';
+
+    if not v_is_safe then
+        raise exception 'Esta migración solo puede ejecutarse en bases de datos de desarrollo. Base de datos actual: %', v_db_name;
+    end if;
+end $$;
+
+begin;
+
+insert into public.businesses (id, name, slug, phone, email, address, metadata)
+values 
+(
+  '11111111-1111-1111-1111-111111111111',
+  'Clínica Belleza Madrid Centro',
+  'belleza-madrid-centro',
+  '+34911222333',
+  'info@bellezamadrid.com',
+  'Calle Gran Vía 123, Madrid',
+  '{"is_test": true, "city": "Madrid"}'::jsonb
+),
+(
+  '22222222-2222-2222-2222-222222222222',
+  'Spa Relax Barcelona',
+  'spa-relax-barcelona',
+  '+34933444555',
+  'hola@sparelax.com',
+  'Passeig de Gràcia 45, Barcelona',
+  '{"is_test": true, "city": "Barcelona"}'::jsonb
+)
+on conflict (id) do update set
+  name = excluded.name,
+  slug = excluded.slug,
+  phone = excluded.phone,
+  email = excluded.email,
+  address = excluded.address,
+  metadata = excluded.metadata;
+
+raise notice 'Negocios de prueba creados';
+
+insert into public.business_settings (business_id, setting_key, setting_value, description)
+values 
+(
+  '11111111-1111-1111-1111-111111111111',
+  'business_hours',
+  '{
+    "timezone": "Europe/Madrid",
+    "schedule": {
+      "monday": {"open": "09:00", "close": "20:00"},
+      "tuesday": {"open": "09:00", "close": "20:00"},
+      "wednesday": {"open": "09:00", "close": "20:00"},
+      "thursday": {"open": "09:00", "close": "20:00"},
+      "friday": {"open": "09:00", "close": "20:00"},
+      "saturday": {"open": "09:00", "close": "18:00"},
+      "sunday": {"closed": true}
+    },
+    "holidays": ["2025-01-01", "2025-01-06", "2025-05-01", "2025-12-25"]
+  }'::jsonb,
+  'Horario de atención - Madrid'
+),
+(
+  '11111111-1111-1111-1111-111111111111',
+  'cancellation_policy',
+  '{
+    "hours_notice": 24,
+    "penalty_percentage": 50,
+    "allow_same_day": false,
+    "free_cancellation_window_hours": 48
+  }'::jsonb,
+  'Política de cancelaciones'
+),
+(
+  '11111111-1111-1111-1111-111111111111',
+  'pricing_rules',
+  '{
+    "min_price": 10.00,
+    "max_price": 500.00,
+    "deposit_required_above": 100.00,
+    "deposit_percentage": 30,
+    "currency": "EUR"
+  }'::jsonb,
+  'Reglas de precios'
+)
+on conflict (business_id, setting_key) do update set
+  setting_value = excluded.setting_value,
+  description = excluded.description;
+
+raise notice 'Configuración del negocio 1 (Madrid) creada';
+
+insert into public.business_settings (business_id, setting_key, setting_value, description)
+values 
+(
+  '22222222-2222-2222-2222-222222222222',
+  'business_hours',
+  '{
+    "timezone": "Europe/Madrid",
+    "schedule": {
+      "monday": {"open": "10:00", "close": "22:00"},
+      "tuesday": {"open": "10:00", "close": "22:00"},
+      "wednesday": {"open": "10:00", "close": "22:00"},
+      "thursday": {"open": "10:00", "close": "22:00"},
+      "friday": {"open": "10:00", "close": "22:00"},
+      "saturday": {"open": "10:00", "close": "22:00"},
+      "sunday": {"open": "10:00", "close": "20:00"}
+    },
+    "holidays": []
+  }'::jsonb,
+  'Horario de atención - Barcelona (7 días)'
+),
+(
+  '22222222-2222-2222-2222-222222222222',
+  'pricing_rules',
+  '{
+    "min_price": 15.00,
+    "max_price": 800.00,
+    "deposit_required_above": 150.00,
+    "deposit_percentage": 40,
+    "currency": "EUR"
+  }'::jsonb,
+  'Reglas de precios - Barcelona'
+)
+on conflict (business_id, setting_key) do update set
+  setting_value = excluded.setting_value,
+  description = excluded.description;
+
+raise notice 'Configuración del negocio 2 (Barcelona) creada';
+
+update public.profiles 
+set business_id = '11111111-1111-1111-1111-111111111111'
+where business_id = '00000000-0000-0000-0000-000000000000';
+
+update public.services 
+set business_id = '11111111-1111-1111-1111-111111111111'
+where business_id = '00000000-0000-0000-0000-000000000000';
+
+update public.appointments 
+set business_id = '11111111-1111-1111-1111-111111111111'
+where business_id = '00000000-0000-0000-0000-000000000000';
+
+update public.resources 
+set business_id = '11111111-1111-1111-1111-111111111111'
+where business_id = '00000000-0000-0000-0000-000000000000';
+
+update public.inventory 
+set business_id = '11111111-1111-1111-1111-111111111111'
+where business_id = '00000000-0000-0000-0000-000000000000';
+
+update public.knowledge_base 
+set business_id = '11111111-1111-1111-1111-111111111111'
+where business_id = '00000000-0000-0000-0000-000000000000';
+
+update public.cross_sell_rules 
+set business_id = '11111111-1111-1111-1111-111111111111'
+where business_id = '00000000-0000-0000-0000-000000000000';
+
+update public.service_resource_requirements 
+set business_id = '11111111-1111-1111-1111-111111111111'
+where business_id = '00000000-0000-0000-0000-000000000000';
+
+update public.resource_blocks 
+set business_id = '11111111-1111-1111-1111-111111111111'
+where business_id = '00000000-0000-0000-0000-000000000000';
+
+raise notice 'Datos existentes reasignados al negocio 1';
+
+select public.generate_test_appointments(90, 30, 8);
+
+raise notice 'Citas de prueba generadas';
+
+commit;
+
+raise notice '========================================';
+raise notice 'Migración 0207_update_seed_multitenancy completada';
+raise notice '';
+raise notice 'Negocios de prueba creados:';
+raise notice '  1. Clínica Belleza Madrid Centro';
+raise notice '  2. Spa Relax Barcelona';
+raise notice '========================================';

--- a/supabase/migrations/0208_validate_business_hours.sql
+++ b/supabase/migrations/0208_validate_business_hours.sql
@@ -1,0 +1,33 @@
+-- ===============================================
+-- Migration: 0208_validate_business_hours.sql
+-- Purpose: Enforce business-hour scheduling for appointments
+-- Dependencies: 0203_business_settings.sql
+-- ===============================================
+
+begin;
+
+-- Ensure appointments respect configured business hours
+alter table public.appointments
+  drop constraint if exists appt_within_business_hours;
+
+alter table public.appointments
+  add constraint appt_within_business_hours
+  check (
+    public.is_within_business_hours(business_id, start_time)
+    and public.is_within_business_hours(
+      business_id,
+      case
+        when end_time is null or end_time <= start_time then start_time
+        else end_time - interval '1 second'
+      end
+    )
+  );
+
+comment on constraint appt_within_business_hours on public.appointments is
+  'Las citas deben comenzar y finalizar dentro del horario laboral configurado del negocio.';
+
+commit;
+
+raise notice '========================================';
+raise notice 'Migración 0208_validate_business_hours completada';
+raise notice '========================================';


### PR DESCRIPTION
## Summary
- add business_id support and composite foreign keys so appointment resources, waitlists, cross-sell rules, and other relations stay inside their tenant without expensive subqueries
- scope appointment resource RLS and RPCs to the active business while ensuring inserts carry the tenant id
- make business hours locale-agnostic and guard cancellation logging when no JWT is present
- enforce that appointments start and end inside the business’s configured working hours via a dedicated constraint

## Testing
- not run (migrations only)

------
https://chatgpt.com/codex/tasks/task_e_68dc53d4a080832792ba8e423d2fd1b5