### PR TITLE
Add no-show tracking and notification template updates

### DIFF
--- a/supabase/migrations/0220_google_calendar_sync.sql
+++ b/supabase/migrations/0220_google_calendar_sync.sql
@@ -1,0 +1,130 @@
+-- ===============================================
+-- Migration: 0220_google_calendar_sync.sql
+-- Purpose: Sincronización bidireccional con Google Calendar
+-- Dependencies: 0004_functions_triggers.sql, 0215_payment_tracking.sql
+-- ===============================================
+
+-- Verificar dependencias necesarias
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.tables
+    WHERE table_schema = 'public'
+      AND table_name = 'appointments'
+  ) THEN
+    RAISE EXCEPTION E'❌ DEPENDENCIA FALTANTE\n\nRequiere: tabla appointments\nAplicar migraciones iniciales de base de datos.';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE p.proname = 'get_user_business_id'
+      AND n.nspname = 'public'
+      AND p.proargtypes = ''::oidvector
+  ) THEN
+    RAISE EXCEPTION E'❌ DEPENDENCIA FALTANTE\n\nRequiere: función public.get_user_business_id()';
+  END IF;
+
+  RAISE NOTICE '✅ Dependencias verificadas';
+END $$;
+
+BEGIN;
+
+-- Tabla de sincronización con Google Calendar
+CREATE TABLE IF NOT EXISTS public.calendar_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id uuid NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  appointment_id uuid REFERENCES public.appointments(id) ON DELETE CASCADE,
+  google_event_id text NOT NULL,
+  calendar_id text NOT NULL,
+  last_synced_at timestamptz DEFAULT now(),
+  sync_status text DEFAULT 'synced' CHECK (sync_status IN ('synced', 'pending', 'failed')),
+  error_message text,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.calendar_events IS
+  'Sincronización de citas con Google Calendar. Mantiene mapping entre appointments y eventos de Google.';
+COMMENT ON COLUMN public.calendar_events.business_id IS
+  'Identificador del negocio al que pertenece el evento sincronizado.';
+COMMENT ON COLUMN public.calendar_events.appointment_id IS
+  'Referencia a la cita interna sincronizada con Google Calendar.';
+COMMENT ON COLUMN public.calendar_events.google_event_id IS
+  'ID del evento en Google Calendar usado para sincronización bidireccional.';
+COMMENT ON COLUMN public.calendar_events.calendar_id IS
+  'Cuenta o calendario de Google (generalmente un email) donde vive el evento.';
+COMMENT ON COLUMN public.calendar_events.sync_status IS
+  'Estado de sincronización: synced, pending o failed.';
+
+-- Índices requeridos (incluyen restricciones únicas)
+CREATE UNIQUE INDEX IF NOT EXISTS idx_calendar_events_appointment
+  ON public.calendar_events(appointment_id);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'calendar_events_appointment_unique'
+      AND conrelid = 'public.calendar_events'::regclass
+  ) THEN
+    ALTER TABLE public.calendar_events
+      ADD CONSTRAINT calendar_events_appointment_unique
+      UNIQUE USING INDEX idx_calendar_events_appointment;
+  END IF;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_calendar_events_google
+  ON public.calendar_events(google_event_id);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'calendar_events_google_event_unique'
+      AND conrelid = 'public.calendar_events'::regclass
+  ) THEN
+    ALTER TABLE public.calendar_events
+      ADD CONSTRAINT calendar_events_google_event_unique
+      UNIQUE USING INDEX idx_calendar_events_google;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_calendar_events_status
+  ON public.calendar_events(sync_status)
+  WHERE sync_status <> 'synced';
+
+-- RLS
+ALTER TABLE public.calendar_events ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS calendar_events_owner_all ON public.calendar_events;
+CREATE POLICY calendar_events_owner_all ON public.calendar_events
+  FOR ALL TO authenticated
+  USING (
+    auth.jwt()->>'user_role' = 'owner'
+    AND business_id = public.get_user_business_id()
+  )
+  WITH CHECK (
+    auth.jwt()->>'user_role' = 'owner'
+    AND business_id = public.get_user_business_id()
+  );
+
+DROP POLICY IF EXISTS calendar_events_lead_read ON public.calendar_events;
+CREATE POLICY calendar_events_lead_read ON public.calendar_events
+  FOR SELECT TO authenticated
+  USING (
+    business_id = public.get_user_business_id()
+    AND EXISTS (
+      SELECT 1
+      FROM public.appointments a
+      JOIN public.profiles p ON p.id = a.profile_id
+      WHERE a.id = calendar_events.appointment_id
+        AND a.business_id = calendar_events.business_id
+        AND p.phone_number = (auth.jwt()->>'phone_number')
+    )
+  );
+
+COMMIT;
+
+RAISE NOTICE '✅ Migración 0220_google_calendar_sync aplicada correctamente';

--- a/supabase/migrations/0221_notification_templates.sql
+++ b/supabase/migrations/0221_notification_templates.sql
@@ -1,0 +1,135 @@
+-- ===============================================
+-- Migration: 0221_notification_templates.sql
+-- Purpose: Sistema de plantillas personalizables para notificaciones
+-- Dependencies: 0004_functions_triggers.sql, 0006_policies_rls_grants.sql
+-- ===============================================
+
+-- Validar dependencias indispensables
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.tables
+    WHERE table_schema = 'public'
+      AND table_name = 'businesses'
+  ) THEN
+    RAISE EXCEPTION E'❌ DEPENDENCIA FALTANTE\n\nRequiere: tabla businesses.';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE p.proname = 'set_updated_at'
+      AND n.nspname = 'public'
+  ) THEN
+    RAISE EXCEPTION E'❌ DEPENDENCIA FALTANTE\n\nRequiere: función public.set_updated_at()';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE p.proname = 'get_user_business_id'
+      AND n.nspname = 'public'
+      AND p.proargtypes = ''::oidvector
+  ) THEN
+    RAISE EXCEPTION E'❌ DEPENDENCIA FALTANTE\n\nRequiere: función public.get_user_business_id()';
+  END IF;
+
+  RAISE NOTICE '✅ Dependencias verificadas';
+END $$;
+
+BEGIN;
+
+-- Tabla de plantillas de notificación
+CREATE TABLE IF NOT EXISTS public.notification_templates (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id uuid NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  template_key text NOT NULL,
+  channel text NOT NULL CHECK (channel IN ('email', 'whatsapp')),
+  subject text,
+  body_template text NOT NULL,
+  variables jsonb NOT NULL DEFAULT '{}'::jsonb,
+  is_active boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT notification_templates_unique_key UNIQUE (business_id, template_key, channel),
+  CONSTRAINT notification_templates_subject_required CHECK (
+    (channel = 'email' AND subject IS NOT NULL) OR channel <> 'email'
+  )
+);
+
+COMMENT ON TABLE public.notification_templates IS
+  'Plantillas dinámicas para emails y WhatsApp personalizables por negocio.';
+COMMENT ON COLUMN public.notification_templates.business_id IS
+  'Negocio propietario de la plantilla de notificación.';
+COMMENT ON COLUMN public.notification_templates.template_key IS
+  'Identificador lógico de la plantilla (appointment_confirmation, reminder, etc.).';
+COMMENT ON COLUMN public.notification_templates.channel IS
+  'Canal de envío soportado: email o whatsapp.';
+COMMENT ON COLUMN public.notification_templates.body_template IS
+  'Contenido de la notificación con variables {{variable}} reemplazables.';
+COMMENT ON COLUMN public.notification_templates.variables IS
+  'Diccionario JSON con variables disponibles y ejemplos de uso.';
+COMMENT ON COLUMN public.notification_templates.subject IS
+  'Asunto del correo electrónico; solo aplicable para canal email.';
+
+-- Índices
+CREATE INDEX IF NOT EXISTS idx_templates_business
+  ON public.notification_templates(business_id);
+
+CREATE INDEX IF NOT EXISTS idx_templates_active
+  ON public.notification_templates(business_id, is_active)
+  WHERE is_active = true;
+
+-- Trigger de actualización automática de updated_at
+DROP TRIGGER IF EXISTS trg_notification_templates_updated_at ON public.notification_templates;
+CREATE TRIGGER trg_notification_templates_updated_at
+  BEFORE UPDATE ON public.notification_templates
+  FOR EACH ROW
+  EXECUTE FUNCTION public.set_updated_at();
+
+-- RLS: solo owners del negocio
+ALTER TABLE public.notification_templates ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS notification_templates_owner_all ON public.notification_templates;
+CREATE POLICY notification_templates_owner_all ON public.notification_templates
+  FOR ALL TO authenticated
+  USING (
+    auth.jwt()->>'user_role' = 'owner'
+    AND business_id = public.get_user_business_id()
+  )
+  WITH CHECK (
+    auth.jwt()->>'user_role' = 'owner'
+    AND business_id = public.get_user_business_id()
+  );
+
+-- Seed de plantilla por defecto
+INSERT INTO public.notification_templates (
+  business_id,
+  template_key,
+  channel,
+  subject,
+  body_template,
+  variables
+) VALUES (
+  '11111111-1111-1111-1111-111111111111',
+  'appointment_confirmation',
+  'email',
+  'Confirmación de tu cita - {{business_name}}',
+  'Hola {{client_name}},\nTu cita ha sido confirmada:\n\nServicio: {{service_name}}\nFecha: {{appointment_date}}\nHora: {{appointment_time}}\nPrecio: {{service_price}}€\n\nPolítica de cancelación: Puedes cancelar con 24h de anticipación sin cargo.\n¡Te esperamos!\n{{business_name}}',
+  jsonb_build_object(
+    'business_name', 'Axonic Wellness',
+    'client_name', 'María García',
+    'service_name', 'Masaje relajante',
+    'appointment_date', '2024-05-18',
+    'appointment_time', '17:30',
+    'service_price', '60'
+  )
+)
+ON CONFLICT (business_id, template_key, channel) DO NOTHING;
+
+COMMIT;
+
+RAISE NOTICE '✅ Migración 0221_notification_templates aplicada correctamente';

--- a/supabase/migrations/0222_fix_rls_security_and_no_shows.sql
+++ b/supabase/migrations/0222_fix_rls_security_and_no_shows.sql
@@ -1,0 +1,352 @@
+-- ===============================================
+-- Migration: 0222_fix_rls_security_and_no_shows.sql
+-- Purpose: Corregir política vulnerable y habilitar sistema de no-shows
+-- Dependencies: 0004_functions_triggers.sql, 0206_update_rls_deep.sql
+-- ===============================================
+
+-- Validar dependencias críticas
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public'
+      AND table_name = 'profiles'
+  ) THEN
+    RAISE EXCEPTION '❌ Falta tabla profiles. Aplicar migraciones base.';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public'
+      AND table_name = 'appointments'
+  ) THEN
+    RAISE EXCEPTION '❌ Falta tabla appointments. Aplicar migraciones base.';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public'
+      AND table_name = 'services'
+  ) THEN
+    RAISE EXCEPTION '❌ Falta tabla services. Aplicar migraciones base.';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public'
+      AND table_name = 'businesses'
+  ) THEN
+    RAISE EXCEPTION '❌ Falta tabla businesses. Aplicar migraciones base.';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE p.proname = 'get_user_business_id'
+      AND n.nspname = 'public'
+      AND p.proargtypes = ''::oidvector
+  ) THEN
+    RAISE EXCEPTION '❌ Dependencia faltante: función public.get_user_business_id()';
+  END IF;
+
+  RAISE NOTICE '✅ Dependencias verificadas';
+END $$;
+
+BEGIN;
+
+-- ===============================================
+-- Parte A: Política segura para perfiles
+-- ===============================================
+DROP POLICY IF EXISTS profiles_read ON public.profiles;
+CREATE POLICY profiles_read ON public.profiles
+  FOR SELECT TO authenticated
+  USING (
+    business_id = public.get_user_business_id()
+    AND (
+      auth.jwt()->>'user_role' = 'owner'
+      OR phone_number = (auth.jwt()->>'phone_number')
+    )
+  );
+
+-- ===============================================
+-- Parte B: Campos de no-show en appointments
+-- ===============================================
+ALTER TABLE public.appointments
+  ADD COLUMN IF NOT EXISTS no_show boolean DEFAULT false,
+  ADD COLUMN IF NOT EXISTS marked_no_show_at timestamptz,
+  ADD COLUMN IF NOT EXISTS marked_no_show_by uuid REFERENCES public.profiles(id) ON DELETE SET NULL;
+
+COMMENT ON COLUMN public.appointments.no_show IS
+  'Indica si la cita fue marcada como no-show.';
+COMMENT ON COLUMN public.appointments.marked_no_show_at IS
+  'Fecha en la que se marcó la cita como no-show.';
+COMMENT ON COLUMN public.appointments.marked_no_show_by IS
+  'Perfil del equipo que marcó la cita como no-show.';
+
+CREATE INDEX IF NOT EXISTS idx_appointments_no_show
+  ON public.appointments (business_id, no_show)
+  WHERE no_show = true;
+
+-- ===============================================
+-- Historial de no-shows por cliente
+-- ===============================================
+CREATE TABLE IF NOT EXISTS public.client_no_show_history (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  profile_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  business_id uuid NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  appointment_id uuid REFERENCES public.appointments(id) ON DELETE SET NULL,
+  service_id uuid REFERENCES public.services(id) ON DELETE SET NULL,
+  scheduled_time timestamptz NOT NULL,
+  marked_at timestamptz NOT NULL DEFAULT now(),
+  notes text,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.client_no_show_history IS
+  'Registro histórico de no-shows para identificar clientes de alto riesgo, definir depósitos obligatorios y decidir futuras reservas.';
+COMMENT ON COLUMN public.client_no_show_history.profile_id IS
+  'Cliente afectado por el no-show.';
+COMMENT ON COLUMN public.client_no_show_history.business_id IS
+  'Negocio propietario del historial.';
+COMMENT ON COLUMN public.client_no_show_history.appointment_id IS
+  'Cita relacionada con el evento de no-show.';
+COMMENT ON COLUMN public.client_no_show_history.service_id IS
+  'Servicio originalmente reservado en la cita.';
+COMMENT ON COLUMN public.client_no_show_history.scheduled_time IS
+  'Horario planificado de la cita marcada como no-show.';
+COMMENT ON COLUMN public.client_no_show_history.notes IS
+  'Notas internas con contexto del no-show.';
+
+CREATE INDEX IF NOT EXISTS idx_no_show_history_profile
+  ON public.client_no_show_history (profile_id, marked_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_no_show_history_business
+  ON public.client_no_show_history (business_id, marked_at DESC);
+
+-- ===============================================
+-- Vista de fiabilidad de clientes
+-- ===============================================
+DROP VIEW IF EXISTS public.client_reliability_score;
+CREATE OR REPLACE VIEW public.client_reliability_score
+WITH (security_barrier = true)
+AS
+WITH base AS (
+  SELECT
+    a.profile_id,
+    a.business_id,
+    COUNT(*) AS total_appointments,
+    COUNT(*) FILTER (
+      WHERE a.status = 'confirmed'
+        AND COALESCE(a.no_show, false) = false
+        AND a.start_time < now()
+    ) AS completed_appointments,
+    COUNT(*) FILTER (
+      WHERE COALESCE(a.no_show, false) = true
+    ) AS no_show_count,
+    COUNT(*) FILTER (
+      WHERE a.status = 'cancelled'
+    ) AS cancellation_count
+  FROM public.appointments a
+  WHERE a.deleted_at IS NULL
+  GROUP BY a.profile_id, a.business_id
+), enriched AS (
+  SELECT
+    b.profile_id,
+    b.business_id,
+    b.total_appointments,
+    b.completed_appointments,
+    b.no_show_count,
+    b.cancellation_count,
+    CASE
+      WHEN b.total_appointments = 0 THEN 100::numeric
+      ELSE ROUND((b.completed_appointments::numeric / b.total_appointments::numeric) * 100, 2)
+    END AS reliability_score,
+    ns.last_no_show_date,
+    CASE
+      WHEN b.total_appointments = 0 THEN 'low'
+      ELSE (
+        CASE
+          WHEN (b.no_show_count::numeric / NULLIF(b.total_appointments::numeric, 0)) * 100 > 25 THEN 'high'
+          WHEN (b.no_show_count::numeric / NULLIF(b.total_appointments::numeric, 0)) * 100 >= 10 THEN 'medium'
+          ELSE 'low'
+        END
+      )
+    END AS risk_level
+  FROM base b
+  LEFT JOIN (
+    SELECT profile_id, business_id, MAX(marked_at) AS last_no_show_date
+    FROM public.client_no_show_history
+    GROUP BY profile_id, business_id
+  ) ns
+    ON ns.profile_id = b.profile_id
+   AND ns.business_id = b.business_id
+)
+SELECT
+  e.profile_id,
+  e.business_id,
+  e.total_appointments,
+  e.completed_appointments,
+  e.no_show_count,
+  e.cancellation_count,
+  e.reliability_score,
+  e.last_no_show_date,
+  e.risk_level
+FROM enriched e
+JOIN public.profiles p ON p.id = e.profile_id
+WHERE
+  p.deleted_at IS NULL
+  AND (
+    (
+      auth.jwt()->>'user_role' = 'owner'
+      AND e.business_id = public.get_user_business_id()
+    )
+    OR (
+      auth.jwt()->>'user_role' = 'lead'
+      AND e.business_id = public.get_user_business_id()
+      AND p.phone_number = (auth.jwt()->>'phone_number')
+    )
+  );
+
+COMMENT ON VIEW public.client_reliability_score IS
+  'Mide el desempeño de asistencia de cada cliente por negocio, incluyendo puntuación, últimos no-shows y nivel de riesgo.';
+
+-- ===============================================
+-- Función para marcar no-shows
+-- ===============================================
+DROP FUNCTION IF EXISTS public.mark_appointment_as_no_show(uuid, text);
+CREATE OR REPLACE FUNCTION public.mark_appointment_as_no_show(
+  p_appointment_id uuid,
+  p_notes text DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_business_id uuid := public.get_user_business_id();
+  v_user_role text := auth.jwt()->>'user_role';
+  v_marker_profile uuid;
+  v_now timestamptz := now();
+  v_appointment RECORD;
+  v_history_id uuid;
+BEGIN
+  IF v_user_role IS DISTINCT FROM 'owner' THEN
+    RAISE EXCEPTION 'Solo los owners pueden marcar no-shows';
+  END IF;
+
+  SELECT
+    a.id,
+    a.profile_id,
+    a.service_id,
+    a.start_time,
+    a.status,
+    a.no_show,
+    a.deleted_at
+  INTO v_appointment
+  FROM public.appointments a
+  WHERE a.id = p_appointment_id
+    AND a.business_id = v_business_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Cita no encontrada para el negocio actual';
+  END IF;
+
+  IF v_appointment.deleted_at IS NOT NULL THEN
+    RAISE EXCEPTION 'No se pueden marcar citas eliminadas';
+  END IF;
+
+  IF COALESCE(v_appointment.no_show, false) THEN
+    RAISE EXCEPTION 'La cita ya estaba marcada como no-show';
+  END IF;
+
+  IF v_appointment.start_time >= v_now THEN
+    RAISE EXCEPTION 'La cita aún no ha sucedido';
+  END IF;
+
+  IF v_appointment.status <> 'confirmed' THEN
+    RAISE EXCEPTION 'Solo se pueden marcar como no-show citas confirmadas';
+  END IF;
+
+  SELECT id
+  INTO v_marker_profile
+  FROM public.profiles
+  WHERE business_id = v_business_id
+    AND phone_number = (auth.jwt()->>'phone_number')
+  LIMIT 1;
+
+  UPDATE public.appointments
+  SET
+    no_show = true,
+    marked_no_show_at = v_now,
+    marked_no_show_by = v_marker_profile,
+    updated_at = v_now
+  WHERE id = v_appointment.id;
+
+  INSERT INTO public.client_no_show_history (
+    profile_id,
+    business_id,
+    appointment_id,
+    service_id,
+    scheduled_time,
+    notes
+  ) VALUES (
+    v_appointment.profile_id,
+    v_business_id,
+    v_appointment.id,
+    v_appointment.service_id,
+    v_appointment.start_time,
+    p_notes
+  )
+  RETURNING id INTO v_history_id;
+
+  INSERT INTO public.audit_logs (business_id, profile_id, action, payload)
+  VALUES (
+    v_business_id,
+    v_marker_profile,
+    'appointment_marked_no_show',
+    jsonb_build_object(
+      'appointment_id', v_appointment.id,
+      'profile_id', v_appointment.profile_id,
+      'service_id', v_appointment.service_id,
+      'scheduled_time', v_appointment.start_time,
+      'notes', p_notes,
+      'marked_at', v_now
+    )
+  );
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'appointment_id', v_appointment.id,
+    'history_id', v_history_id,
+    'marked_at', v_now
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.mark_appointment_as_no_show(uuid, text) IS
+  'Marca una cita confirmada como no-show, registra historial y crea auditoría.';
+
+GRANT EXECUTE ON FUNCTION public.mark_appointment_as_no_show(uuid, text) TO authenticated;
+
+-- ===============================================
+-- RLS para historial de no-shows
+-- ===============================================
+ALTER TABLE public.client_no_show_history ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS client_no_show_history_owner_all ON public.client_no_show_history;
+CREATE POLICY client_no_show_history_owner_all ON public.client_no_show_history
+  FOR ALL TO authenticated
+  USING (
+    auth.jwt()->>'user_role' = 'owner'
+    AND business_id = public.get_user_business_id()
+  )
+  WITH CHECK (
+    auth.jwt()->>'user_role' = 'owner'
+    AND business_id = public.get_user_business_id()
+  );
+
+COMMIT;
+
+RAISE NOTICE '✅ Migración 0222_fix_rls_security_and_no_shows aplicada correctamente';

--- a/supabase/migrations/0223_update_notification_templates.sql
+++ b/supabase/migrations/0223_update_notification_templates.sql
@@ -1,0 +1,85 @@
+-- ===============================================
+-- Migration: 0223_update_notification_templates.sql
+-- Purpose: Actualizar plantillas con política de cancelación variable y nuevas notificaciones
+-- Dependencies: 0221_notification_templates.sql
+-- ===============================================
+
+-- Validar dependencias
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public'
+      AND table_name = 'notification_templates'
+  ) THEN
+    RAISE EXCEPTION '❌ Falta tabla notification_templates. Aplicar migración 0221 primero.';
+  END IF;
+
+  RAISE NOTICE '✅ Dependencias verificadas';
+END $$;
+
+BEGIN;
+
+-- Actualizar plantilla de confirmación existente
+UPDATE public.notification_templates
+SET
+  body_template = 'Hola {{client_name}},\nTu cita ha sido confirmada:\n\nServicio: {{service_name}}\nFecha: {{appointment_date}}\nHora: {{appointment_time}}\nPrecio: {{service_price}}€\n\n¡Te esperamos!\n{{business_name}}\n\n{{cancellation_policy}}',
+  variables = COALESCE(variables, '{}'::jsonb) || jsonb_build_object(
+    'cancellation_policy', 'Puedes cancelar con 24h de anticipación sin cargo'
+  )
+WHERE business_id = '11111111-1111-1111-1111-111111111111'
+  AND template_key = 'appointment_confirmation'
+  AND channel = 'email';
+
+-- Insertar plantilla para advertencia de no-show (WhatsApp)
+INSERT INTO public.notification_templates (
+  business_id,
+  template_key,
+  channel,
+  subject,
+  body_template,
+  variables
+) VALUES (
+  '11111111-1111-1111-1111-111111111111',
+  'no_show_warning',
+  'whatsapp',
+  NULL,
+  'Hola {{client_name}},\n\nNotamos que no pudiste asistir a tu cita del {{appointment_date}} para {{service_name}}.\n\nEntendemos que pueden surgir imprevistos. Te recordamos que puedes cancelar con anticipación para que otros clientes puedan aprovechar el horario.\n\n¿Te gustaría reagendar?\n\nSaludos,\n{{business_name}}',
+  jsonb_build_object(
+    'client_name', 'María García',
+    'appointment_date', '2024-05-18',
+    'service_name', 'Masaje relajante',
+    'business_name', 'Axonic Wellness'
+  )
+)
+ON CONFLICT (business_id, template_key, channel) DO NOTHING;
+
+-- Insertar plantilla para recordatorio de cita (WhatsApp)
+INSERT INTO public.notification_templates (
+  business_id,
+  template_key,
+  channel,
+  subject,
+  body_template,
+  variables
+) VALUES (
+  '11111111-1111-1111-1111-111111111111',
+  'appointment_reminder',
+  'whatsapp',
+  NULL,
+  'Hola {{client_name}}! 👋\n\nTe recordamos tu cita de mañana:\n\n📅 {{appointment_date}} a las {{appointment_time}}\n💆‍♀️ {{service_name}}\n💰 {{service_price}}€\n\n{{cancellation_policy}}\n\n¡Te esperamos!\n{{business_name}}',
+  jsonb_build_object(
+    'client_name', 'María García',
+    'appointment_date', '2024-05-18',
+    'appointment_time', '17:30',
+    'service_name', 'Masaje relajante',
+    'service_price', '60',
+    'cancellation_policy', 'Puedes cancelar con 24h de anticipación sin cargo',
+    'business_name', 'Axonic Wellness'
+  )
+)
+ON CONFLICT (business_id, template_key, channel) DO NOTHING;
+
+COMMIT;
+
+RAISE NOTICE '✅ Migración 0223_update_notification_templates aplicada correctamente';


### PR DESCRIPTION
## Summary
- harden the `profiles_read` policy and extend appointments with no-show tracking fields, history table, reliability view, and helper function
- seed risk-focused notification templates and update the confirmation template to use a configurable cancellation policy

## Testing
- not run (SQL migrations only)

------
https://chatgpt.com/codex/tasks/task_e_68de627c146883279e796031d7b1b5bb